### PR TITLE
상점의 위도 경도를 Point 자료형으로 저장하도록 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,10 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+    // Point 자료형
+    implementation 'org.locationtech.jts:jts-core:1.18.0'
+    implementation 'org.hibernate:hibernate-spatial:6.5.2.Final'
+
     // test implementation dependencies
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 

--- a/src/main/java/wad/seoul_nolgoat/domain/store/Store.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/store/Store.java
@@ -4,6 +4,9 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
 import wad.seoul_nolgoat.domain.BaseTimeEntity;
 import wad.seoul_nolgoat.domain.review.Review;
 
@@ -28,8 +31,7 @@ public class Store extends BaseTimeEntity {
     private String phoneNumber;
     private String lotAddress;
     private String roadAddress;
-    private double latitude;
-    private double longitude;
+    private Point location;
     private double kakaoAverageGrade;
     private double nolgoatAverageGrade;
     private String placeUrl;
@@ -69,15 +71,13 @@ public class Store extends BaseTimeEntity {
         this.phoneNumber = phoneNumber;
         this.lotAddress = lotAddress;
         this.roadAddress = roadAddress;
-        this.latitude = latitude;
-        this.longitude = longitude;
+        setLocation(longitude, latitude);
         this.kakaoAverageGrade = kakaoAverageGrade;
         this.placeUrl = placeUrl;
     }
 
-    public void updateCoordinates(double latitude, double longitude) {
-        this.latitude = latitude;
-        this.longitude = longitude;
+    public void updateCoordinates(double longitude, double latitude) {
+        setLocation(longitude, latitude);
     }
 
     public void updateAdditionalInfo(
@@ -95,5 +95,18 @@ public class Store extends BaseTimeEntity {
 
     public void delete() {
         this.isDeleted = true;
+    }
+
+    public double getLongitude() {
+        return location.getX();
+    }
+
+    public double getLatitude() {
+        return location.getY();
+    }
+
+    private void setLocation(double longitude, double latitude) {
+        GeometryFactory geometryFactory = new GeometryFactory();
+        this.location = geometryFactory.createPoint(new Coordinate(longitude, latitude));
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/domain/store/StoreRepositoryCustomImpl.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/store/StoreRepositoryCustomImpl.java
@@ -6,7 +6,6 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import wad.seoul_nolgoat.service.search.dto.StoreForDistanceSortDto;
 import wad.seoul_nolgoat.service.search.dto.StoreForGradeSortDto;
-import wad.seoul_nolgoat.service.search.sort.DistanceCalculator;
 import wad.seoul_nolgoat.web.search.dto.CoordinateDto;
 
 import java.util.Collections;
@@ -33,8 +32,8 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
                                         store.name,
                                         Projections.constructor(
                                                 CoordinateDto.class,
-                                                store.latitude,
-                                                store.longitude
+                                                numberTemplate(Double.class, "ST_Y({0})", store.location),
+                                                numberTemplate(Double.class, "ST_X({0})", store.location)
                                         )
                                 )
                         )
@@ -60,8 +59,8 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
                                         store.name,
                                         Projections.constructor(
                                                 CoordinateDto.class,
-                                                store.latitude,
-                                                store.longitude
+                                                numberTemplate(Double.class, "ST_Y({0})", store.location),
+                                                numberTemplate(Double.class, "ST_X({0})", store.location)
                                         ),
                                         store.kakaoAverageGrade
                                 )
@@ -88,8 +87,8 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
                                         store.name,
                                         Projections.constructor(
                                                 CoordinateDto.class,
-                                                store.latitude,
-                                                store.longitude
+                                                numberTemplate(Double.class, "ST_Y({0})", store.location),
+                                                numberTemplate(Double.class, "ST_X({0})", store.location)
                                         ),
                                         store.nolgoatAverageGrade
                                 )
@@ -106,12 +105,10 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
     private NumberExpression<Double> calculateHaversineDistance(CoordinateDto startCoordinate) {
         return numberTemplate(
                 Double.class,
-                "{0} * acos(cos(radians({1})) * cos(radians({2})) * cos(radians({3}) - radians({4})) + sin(radians({1})) * sin(radians({2})))",
-                DistanceCalculator.EARTH_RADIUS_KM,
+                "ST_Distance_Sphere(Point({0}, {1}), Point(ST_X({2}), ST_Y({2})))",
+                startCoordinate.getLongitude(),
                 startCoordinate.getLatitude(),
-                store.latitude,
-                store.longitude,
-                startCoordinate.getLongitude()
-        );
+                store.location
+        ).divide(1000.0); // km로 변환
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/service/databaseSeeder/DatabaseSeederService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/databaseSeeder/DatabaseSeederService.java
@@ -86,7 +86,7 @@ public class DatabaseSeederService {
                 Optional<CoordinateDto> optionalCoordinates = kakaoMapService.fetchCoordinate(store.getRoadAddress());
                 if (optionalCoordinates.isPresent()) {
                     CoordinateDto coordinates = optionalCoordinates.get();
-                    store.updateCoordinates(coordinates.getLatitude(), coordinates.getLongitude());
+                    store.updateCoordinates(coordinates.getLongitude(), coordinates.getLatitude());
                 }
             }
         });
@@ -96,7 +96,7 @@ public class DatabaseSeederService {
     public CompletableFuture<Void> updateStoreInfoAsync(Store store) {
         return CompletableFuture.runAsync(() -> {
             rateLimiter.acquire(); // RateLimiter 사용
-            if (store.getLongitude() != 0 && store.getLatitude() != 0) {
+            if (store.getLocation() != null) {
                 Optional<StoreAdditionalInfoDto> optionalStoreAdditionalInfo = kakaoMapService.fetchStoreAdditionalInfo(
                         store.getName(),
                         store.getLongitude(),

--- a/src/main/java/wad/seoul_nolgoat/service/search/SearchService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/search/SearchService.java
@@ -25,6 +25,8 @@ public class SearchService {
     private static final int FIRST_CATEGORY = 0;
     private static final int SECOND_CATEGORY = 1;
     private static final int THIRD_CATEGORY = 2;
+
+    private static final int STORE_COMBINATION_SEARCH_START = 0;
     private static final int STORE_COMBINATION_SEARCH_LIMIT = 10;
 
     private final FilterService filterService;
@@ -45,7 +47,7 @@ public class SearchService {
 
     private List<CombinationDto> getCombinationsByDistance(SearchConditionDto searchConditionDto) {
         if (searchConditionDto.getCategories().size() == THREE_ROUND) {
-            return sortService.sortStoresByDistance(
+            List<CombinationDto> combinationDtos = sortService.sortStoresByDistance(
                             new SortConditionDto<>(
                                     searchConditionDto.getStartCoordinate(),
                                     filterService.filterByRadiusRangeAndCategoryForDistanceSort(
@@ -66,11 +68,15 @@ public class SearchService {
                             )
                     ).stream()
                     .map(CombinationMapper::toCombinationDto)
-                    .limit(STORE_COMBINATION_SEARCH_LIMIT)
                     .toList();
+
+            return combinationDtos.subList(
+                    STORE_COMBINATION_SEARCH_START,
+                    Math.min(STORE_COMBINATION_SEARCH_LIMIT, combinationDtos.size())
+            );
         }
         if (searchConditionDto.getCategories().size() == TWO_ROUND) {
-            return sortService.sortStoresByDistance(
+            List<CombinationDto> combinationDtos = sortService.sortStoresByDistance(
                             new SortConditionDto<>(
                                     searchConditionDto.getStartCoordinate(),
                                     filterService.filterByRadiusRangeAndCategoryForDistanceSort(
@@ -86,11 +92,15 @@ public class SearchService {
                             )
                     ).stream()
                     .map(CombinationMapper::toCombinationDto)
-                    .limit(STORE_COMBINATION_SEARCH_LIMIT)
                     .toList();
+
+            return combinationDtos.subList(
+                    STORE_COMBINATION_SEARCH_START,
+                    Math.min(STORE_COMBINATION_SEARCH_LIMIT, combinationDtos.size())
+            );
         }
         if (searchConditionDto.getCategories().size() == ONE_ROUND) {
-            return sortService.sortStoresByDistance(
+            List<CombinationDto> combinationDtos = sortService.sortStoresByDistance(
                             new SortConditionDto<>(
                                     searchConditionDto.getStartCoordinate(),
                                     filterService.filterByRadiusRangeAndCategoryForDistanceSort(
@@ -101,15 +111,19 @@ public class SearchService {
                             )
                     ).stream()
                     .map(CombinationMapper::toCombinationDto)
-                    .limit(STORE_COMBINATION_SEARCH_LIMIT)
                     .toList();
+
+            return combinationDtos.subList(
+                    STORE_COMBINATION_SEARCH_START,
+                    Math.min(STORE_COMBINATION_SEARCH_LIMIT, combinationDtos.size())
+            );
         }
         throw new RuntimeException();
     }
 
     private List<CombinationDto> getCombinationsByKakaoGrade(SearchConditionDto searchConditionDto) {
         if (searchConditionDto.getCategories().size() == THREE_ROUND) {
-            return sortService.sortStoresByGrade(
+            List<CombinationDto> combinationDtos = sortService.sortStoresByGrade(
                             new SortConditionDto<>(
                                     searchConditionDto.getStartCoordinate(),
                                     filterService.filterByRadiusRangeAndCategoryForKakaoGradeSort(
@@ -130,11 +144,15 @@ public class SearchService {
                             )
                     ).stream()
                     .map(CombinationMapper::toCombinationDto)
-                    .limit(STORE_COMBINATION_SEARCH_LIMIT)
                     .toList();
+
+            return combinationDtos.subList(
+                    STORE_COMBINATION_SEARCH_START,
+                    Math.min(STORE_COMBINATION_SEARCH_LIMIT, combinationDtos.size())
+            );
         }
         if (searchConditionDto.getCategories().size() == TWO_ROUND) {
-            return sortService.sortStoresByGrade(
+            List<CombinationDto> combinationDtos = sortService.sortStoresByGrade(
                             new SortConditionDto<>(
                                     searchConditionDto.getStartCoordinate(),
                                     filterService.filterByRadiusRangeAndCategoryForKakaoGradeSort(
@@ -150,11 +168,15 @@ public class SearchService {
                             )
                     ).stream()
                     .map(CombinationMapper::toCombinationDto)
-                    .limit(STORE_COMBINATION_SEARCH_LIMIT)
                     .toList();
+
+            return combinationDtos.subList(
+                    STORE_COMBINATION_SEARCH_START,
+                    Math.min(STORE_COMBINATION_SEARCH_LIMIT, combinationDtos.size())
+            );
         }
         if (searchConditionDto.getCategories().size() == ONE_ROUND) {
-            return sortService.sortStoresByGrade(
+            List<CombinationDto> combinationDtos = sortService.sortStoresByGrade(
                             new SortConditionDto<>(
                                     searchConditionDto.getStartCoordinate(),
                                     filterService.filterByRadiusRangeAndCategoryForKakaoGradeSort(
@@ -165,15 +187,19 @@ public class SearchService {
                             )
                     ).stream()
                     .map(CombinationMapper::toCombinationDto)
-                    .limit(STORE_COMBINATION_SEARCH_LIMIT)
                     .toList();
+
+            return combinationDtos.subList(
+                    STORE_COMBINATION_SEARCH_START,
+                    Math.min(STORE_COMBINATION_SEARCH_LIMIT, combinationDtos.size())
+            );
         }
         throw new RuntimeException();
     }
 
     private List<CombinationDto> getCombinationsByNolgoatGrade(SearchConditionDto searchConditionDto) {
         if (searchConditionDto.getCategories().size() == THREE_ROUND) {
-            return sortService.sortStoresByGrade(
+            List<CombinationDto> combinationDtos = sortService.sortStoresByGrade(
                             new SortConditionDto<>(
                                     searchConditionDto.getStartCoordinate(),
                                     filterService.filterByRadiusRangeAndCategoryForNolgoatGradeSort(
@@ -194,11 +220,15 @@ public class SearchService {
                             )
                     ).stream()
                     .map(CombinationMapper::toCombinationDto)
-                    .limit(STORE_COMBINATION_SEARCH_LIMIT)
                     .toList();
+
+            return combinationDtos.subList(
+                    STORE_COMBINATION_SEARCH_START,
+                    Math.min(STORE_COMBINATION_SEARCH_LIMIT, combinationDtos.size())
+            );
         }
         if (searchConditionDto.getCategories().size() == TWO_ROUND) {
-            return sortService.sortStoresByGrade(
+            List<CombinationDto> combinationDtos = sortService.sortStoresByGrade(
                             new SortConditionDto<>(
                                     searchConditionDto.getStartCoordinate(),
                                     filterService.filterByRadiusRangeAndCategoryForNolgoatGradeSort(
@@ -214,11 +244,15 @@ public class SearchService {
                             )
                     ).stream()
                     .map(CombinationMapper::toCombinationDto)
-                    .limit(STORE_COMBINATION_SEARCH_LIMIT)
                     .toList();
+
+            return combinationDtos.subList(
+                    STORE_COMBINATION_SEARCH_START,
+                    Math.min(STORE_COMBINATION_SEARCH_LIMIT, combinationDtos.size())
+            );
         }
         if (searchConditionDto.getCategories().size() == ONE_ROUND) {
-            return sortService.sortStoresByGrade(
+            List<CombinationDto> combinationDtos = sortService.sortStoresByGrade(
                             new SortConditionDto<>(
                                     searchConditionDto.getStartCoordinate(),
                                     filterService.filterByRadiusRangeAndCategoryForNolgoatGradeSort(
@@ -229,8 +263,12 @@ public class SearchService {
                             )
                     ).stream()
                     .map(CombinationMapper::toCombinationDto)
-                    .limit(STORE_COMBINATION_SEARCH_LIMIT)
                     .toList();
+
+            return combinationDtos.subList(
+                    STORE_COMBINATION_SEARCH_START,
+                    Math.min(STORE_COMBINATION_SEARCH_LIMIT, combinationDtos.size())
+            );
         }
         throw new RuntimeException();
     }

--- a/src/main/java/wad/seoul_nolgoat/service/search/dto/DistanceSortCombinationDto.java
+++ b/src/main/java/wad/seoul_nolgoat/service/search/dto/DistanceSortCombinationDto.java
@@ -32,6 +32,22 @@ public class DistanceSortCombinationDto {
     public DistanceSortCombinationDto(
             StoreForDistanceSortDto firstStore,
             StoreForDistanceSortDto secondStore,
+            WalkRouteInfoDto walkRouteInfoDto) {
+        this.firstStore = firstStore;
+        this.secondStore = secondStore;
+        this.walkRouteInfoDto = walkRouteInfoDto;
+        this.totalRounds = SearchService.TWO_ROUND;
+    }
+
+    public DistanceSortCombinationDto(StoreForDistanceSortDto firstStore, WalkRouteInfoDto walkRouteInfoDto) {
+        this.firstStore = firstStore;
+        this.walkRouteInfoDto = walkRouteInfoDto;
+        this.totalRounds = SearchService.ONE_ROUND;
+    }
+
+    public DistanceSortCombinationDto(
+            StoreForDistanceSortDto firstStore,
+            StoreForDistanceSortDto secondStore,
             StoreForDistanceSortDto thirdStore) {
         this.firstStore = firstStore;
         this.secondStore = secondStore;

--- a/src/main/java/wad/seoul_nolgoat/service/search/sort/SortService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/search/sort/SortService.java
@@ -32,11 +32,11 @@ public class SortService {
         List<DistanceSortCombinationDto> distanceCombinations = generateAndSortDistanceCombinations(
                 sortConditionDto,
                 totalRounds
-        ).subList(TOP_FIRST, TOP_TWENTIETH);
+        );
 
         return fetchDistancesFromTMapApi(
                 sortConditionDto.getStartCoordinate(),
-                distanceCombinations,
+                distanceCombinations.subList(TOP_FIRST, Math.min(distanceCombinations.size(), TOP_TWENTIETH)),
                 totalRounds
         );
     }

--- a/src/main/java/wad/seoul_nolgoat/service/search/sort/SortService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/search/sort/SortService.java
@@ -279,57 +279,47 @@ public class SortService {
             int totalRounds) {
         List<DistanceSortCombinationDto> combinations = distanceSortCombinationDtos.parallelStream()
                 .map(combination -> {
-                            if (totalRounds == SearchService.THREE_ROUND) {
-                                CoordinateDto pass1 = combination.getFirstStore().getCoordinate();
-                                CoordinateDto pass2 = combination.getSecondStore().getCoordinate();
-                                CoordinateDto endCoordinate = combination.getThirdStore().getCoordinate();
-                                WalkRouteInfoDto walkRouteInfoDto = tMapService.fetchWalkRouteInfo(
+                    if (totalRounds == SearchService.THREE_ROUND) {
+                        CoordinateDto pass1 = combination.getFirstStore().getCoordinate();
+                        CoordinateDto pass2 = combination.getSecondStore().getCoordinate();
+                        CoordinateDto endCoordinate = combination.getThirdStore().getCoordinate();
+
+                        return new DistanceSortCombinationDto(
+                                combination.getFirstStore(),
+                                combination.getSecondStore(),
+                                combination.getThirdStore(),
+                                fetchWalkRouteInfo(
                                         startCoordinate,
                                         pass1,
                                         pass2,
                                         endCoordinate
-                                );
+                                )
+                        );
+                    }
+                    if (totalRounds == SearchService.TWO_ROUND) {
+                        CoordinateDto pass = combination.getFirstStore().getCoordinate();
+                        CoordinateDto endCoordinate = combination.getSecondStore().getCoordinate();
 
-                                return new DistanceSortCombinationDto(
-                                        combination.getFirstStore(),
-                                        combination.getSecondStore(),
-                                        combination.getThirdStore(),
-                                        walkRouteInfoDto
-                                );
-                            }
-                            if (totalRounds == SearchService.TWO_ROUND) {
-                                CoordinateDto pass = combination.getFirstStore().getCoordinate();
-                                CoordinateDto endCoordinate = combination.getSecondStore().getCoordinate();
-                                WalkRouteInfoDto walkRouteInfoDto = tMapService.fetchWalkRouteInfo(
+                        return new DistanceSortCombinationDto(
+                                combination.getFirstStore(),
+                                combination.getSecondStore(),
+                                fetchWalkRouteInfo(
                                         startCoordinate,
                                         pass,
                                         endCoordinate
-                                );
+                                )
+                        );
+                    }
+                    if (totalRounds == SearchService.ONE_ROUND) {
+                        CoordinateDto endCoordinate = combination.getFirstStore().getCoordinate();
 
-                                return new DistanceSortCombinationDto(
-                                        combination.getFirstStore(),
-                                        combination.getSecondStore(),
-                                        combination.getThirdStore(),
-                                        walkRouteInfoDto
-                                );
-                            }
-                            if (totalRounds == SearchService.ONE_ROUND) {
-                                CoordinateDto endCoordinate = combination.getSecondStore().getCoordinate();
-                                WalkRouteInfoDto walkRouteInfoDto = tMapService.fetchWalkRouteInfo(
-                                        startCoordinate,
-                                        endCoordinate
-                                );
-
-                                return new DistanceSortCombinationDto(
-                                        combination.getFirstStore(),
-                                        combination.getSecondStore(),
-                                        combination.getThirdStore(),
-                                        walkRouteInfoDto
-                                );
-                            }
-                            throw new RuntimeException();
-                        }
-                ).toList();
+                        return new DistanceSortCombinationDto(
+                                combination.getFirstStore(),
+                                fetchWalkRouteInfo(startCoordinate, endCoordinate)
+                        );
+                    }
+                    throw new RuntimeException("Invalid round number");
+                }).toList();
 
         return combinations.stream()
                 .sorted(Comparator.comparingInt(combination -> combination.getWalkRouteInfoDto().getTotalDistance()))
@@ -368,11 +358,76 @@ public class SortService {
         return storeIds.size() != SearchService.THREE_ROUND;
     }
 
+    private WalkRouteInfoDto fetchWalkRouteInfo(
+            CoordinateDto startCoordinate,
+            CoordinateDto pass1,
+            CoordinateDto pass2,
+            CoordinateDto endCoordinate) {
+        if (isSameLocation(startCoordinate, pass1) && isSameLocation(pass1, pass2) && isSameLocation(pass2, endCoordinate)) {
+            return new WalkRouteInfoDto(0, 0);
+        }
+        if (isSameLocation(startCoordinate, pass1) && isSameLocation(pass1, pass2)) {
+            return tMapService.fetchWalkRouteInfo(pass2, endCoordinate);
+        }
+        if (isSameLocation(pass1, pass2) && isSameLocation(pass2, endCoordinate)) {
+            return tMapService.fetchWalkRouteInfo(startCoordinate, pass1);
+        }
+        if (isSameLocation(startCoordinate, pass1) && isSameLocation(pass2, endCoordinate)) {
+            return tMapService.fetchWalkRouteInfo(startCoordinate, pass1, endCoordinate);
+        }
+        if (isSameLocation(startCoordinate, pass1)) {
+            return tMapService.fetchWalkRouteInfo(pass1, pass2, endCoordinate);
+        }
+        if (isSameLocation(pass1, pass2)) {
+            WalkRouteInfoDto firstWalkRouteInfo = tMapService.fetchWalkRouteInfo(startCoordinate, pass1);
+            WalkRouteInfoDto secondWalkRouteInfo = tMapService.fetchWalkRouteInfo(pass2, endCoordinate);
+
+            return new WalkRouteInfoDto(
+                    firstWalkRouteInfo.getTotalDistance() + secondWalkRouteInfo.getTotalDistance(),
+                    firstWalkRouteInfo.getTotalTime() + secondWalkRouteInfo.getTotalTime()
+            );
+        }
+
+        return tMapService.fetchWalkRouteInfo(startCoordinate, pass1, pass2, endCoordinate);
+    }
+
+    private WalkRouteInfoDto fetchWalkRouteInfo(
+            CoordinateDto startCoordinate,
+            CoordinateDto pass,
+            CoordinateDto endCoordinate) {
+        if (isSameLocation(startCoordinate, pass) && isSameLocation(pass, endCoordinate)) {
+            return new WalkRouteInfoDto(0, 0);
+        }
+        if (isSameLocation(startCoordinate, pass)) {
+            return tMapService.fetchWalkRouteInfo(pass, endCoordinate);
+        }
+        if (isSameLocation(pass, endCoordinate)) {
+            return tMapService.fetchWalkRouteInfo(startCoordinate, pass);
+        }
+
+        return tMapService.fetchWalkRouteInfo(startCoordinate, pass, endCoordinate);
+    }
+
+    private WalkRouteInfoDto fetchWalkRouteInfo(
+            CoordinateDto startCoordinate,
+            CoordinateDto endCoordinate) {
+        if (isSameLocation(startCoordinate, endCoordinate)) {
+            return new WalkRouteInfoDto(0, 0);
+        }
+
+        return tMapService.fetchWalkRouteInfo(startCoordinate, endCoordinate);
+    }
+
     private boolean hasDuplicateStores(StoreForGradeSortDto firstStore, StoreForGradeSortDto secondStore) {
         Set<Long> storeIds = new HashSet<>();
         storeIds.add(firstStore.getId());
         storeIds.add(secondStore.getId());
 
         return storeIds.size() != SearchService.TWO_ROUND;
+    }
+
+    private boolean isSameLocation(CoordinateDto coordinate1, CoordinateDto coordinate2) {
+        return (coordinate1.getLongitude() == coordinate2.getLongitude())
+                && (coordinate1.getLatitude() == coordinate2.getLatitude());
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/service/search/sort/SortService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/search/sort/SortService.java
@@ -373,10 +373,13 @@ public class SortService {
             return tMapService.fetchWalkRouteInfo(startCoordinate, pass1);
         }
         if (isSameLocation(startCoordinate, pass1) && isSameLocation(pass2, endCoordinate)) {
-            return tMapService.fetchWalkRouteInfo(startCoordinate, pass1, endCoordinate);
+            return tMapService.fetchWalkRouteInfo(pass1, pass2);
         }
         if (isSameLocation(startCoordinate, pass1)) {
             return tMapService.fetchWalkRouteInfo(pass1, pass2, endCoordinate);
+        }
+        if (isSameLocation(pass2, endCoordinate)) {
+            return tMapService.fetchWalkRouteInfo(startCoordinate, pass1, pass2);
         }
         if (isSameLocation(pass1, pass2)) {
             WalkRouteInfoDto firstWalkRouteInfo = tMapService.fetchWalkRouteInfo(startCoordinate, pass1);


### PR DESCRIPTION
### 상점의 위도 경도를 Point 자료형으로 저장
기존 Store 엔터티의 위도 경도 
```java
private String lotAddress;
private String roadAddress;
```

수정된 Store 엔터티의 위도 경도 
```java
private Point location;
```

### TMap API 호출 시 위도 경도가 동일한 상점 처리
좌표가 동일할 때는 TMap API를 호출하지 않고 0 반환

### 검색된 결과가 20 이하일 때 발생하는 오류 처리