### PR TITLE
Review 작성 시 이미지 업로드 기능, Store의 nolgoat 평점 업데이트 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /src/main/resources/oauth2-config.yml
 /src/main/resources/jwt-config.yml
 /src/main/resources/s3-config.yml
+/src/main/resources/multipart-config.yml
 
 ### build ###
 .gradle

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /src/main/resources/t-config.yml
 /src/main/resources/oauth2-config.yml
 /src/main/resources/jwt-config.yml
+/src/main/resources/s3-config.yml
 
 ### build ###
 .gradle

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,9 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+    // AWS
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
     // test implementation dependencies
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 

--- a/src/main/java/wad/seoul_nolgoat/config/S3Config.java
+++ b/src/main/java/wad/seoul_nolgoat/config/S3Config.java
@@ -1,0 +1,33 @@
+package wad.seoul_nolgoat.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return (AmazonS3Client) AmazonS3ClientBuilder
+                .standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .build();
+    }
+}

--- a/src/main/java/wad/seoul_nolgoat/domain/review/Review.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/review/Review.java
@@ -33,7 +33,8 @@ public class Review extends BaseTimeEntity {
             int grade,
             String content,
             User user,
-            Store store) {
+            Store store
+    ) {
         this.grade = grade;
         this.content = content;
         this.user = user;
@@ -46,7 +47,8 @@ public class Review extends BaseTimeEntity {
             String content,
             String imageUrl,
             User user,
-            Store store) {
+            Store store
+    ) {
         this.grade = grade;
         this.content = content;
         this.imageUrl = imageUrl;

--- a/src/main/java/wad/seoul_nolgoat/domain/review/Review.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/review/Review.java
@@ -19,6 +19,7 @@ public class Review extends BaseTimeEntity {
 
     private double grade;
     private String content;
+    private String imageUrl;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
@@ -40,6 +41,20 @@ public class Review extends BaseTimeEntity {
         store.getReviews().add(this);
     }
 
+    public Review(
+            int grade,
+            String content,
+            String imageUrl,
+            User user,
+            Store store) {
+        this.grade = grade;
+        this.content = content;
+        this.imageUrl = imageUrl;
+        this.user = user;
+        this.store = store;
+        store.getReviews().add(this);
+    }
+
     public void update(double grade, String content) {
         this.grade = grade;
         this.content = content;
@@ -47,5 +62,9 @@ public class Review extends BaseTimeEntity {
 
     public void delete() {
         store.getReviews().remove(this);
+    }
+
+    public boolean hasImageUrl() {
+        return this.imageUrl != null && !this.imageUrl.isEmpty();
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/domain/review/Review.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/review/Review.java
@@ -42,7 +42,7 @@ public class Review extends BaseTimeEntity {
     }
 
     public Review(
-            int grade,
+            double grade,
             String content,
             String imageUrl,
             User user,

--- a/src/main/java/wad/seoul_nolgoat/domain/review/Review.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/review/Review.java
@@ -17,7 +17,7 @@ public class Review extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private double grade;
+    private int grade;
     private String content;
     private String imageUrl;
 
@@ -30,7 +30,7 @@ public class Review extends BaseTimeEntity {
     private Store store;
 
     public Review(
-            double grade,
+            int grade,
             String content,
             User user,
             Store store) {
@@ -42,7 +42,7 @@ public class Review extends BaseTimeEntity {
     }
 
     public Review(
-            double grade,
+            int grade,
             String content,
             String imageUrl,
             User user,
@@ -55,7 +55,7 @@ public class Review extends BaseTimeEntity {
         store.getReviews().add(this);
     }
 
-    public void update(double grade, String content) {
+    public void update(int grade, String content) {
         this.grade = grade;
         this.content = content;
     }

--- a/src/main/java/wad/seoul_nolgoat/domain/review/ReviewRepository.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/review/ReviewRepository.java
@@ -7,4 +7,6 @@ import java.util.List;
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     List<Review> findByUserId(Long userId);
+
+    boolean existsByUserIdAndStoreId(Long userId, Long storeId);
 }

--- a/src/main/java/wad/seoul_nolgoat/domain/store/StoreRepository.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/store/StoreRepository.java
@@ -1,6 +1,15 @@
 package wad.seoul_nolgoat.domain.store;
 
+import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface StoreRepository extends JpaRepository<Store, Long>, StoreRepositoryCustom {
+
+    @Transactional
+    @Modifying
+    @Query("UPDATE Store s SET s.nolgoatAverageGrade = :nolgoatAverageGrade WHERE s.id = :storeId")
+    void updateNolgoatAverageGrade(@Param("storeId") Long storeId, @Param("nolgoatAverageGrade") double nolgoatAverageGrade);
 }

--- a/src/main/java/wad/seoul_nolgoat/service/review/ReviewService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/review/ReviewService.java
@@ -35,7 +35,8 @@ public class ReviewService {
             Long userId,
             Long storeId,
             Optional<MultipartFile> optionalMultipartFile,
-            ReviewSaveDto reviewSaveDto) {
+            ReviewSaveDto reviewSaveDto
+    ) {
         if (reviewRepository.existsByUserIdAndStoreId(userId, storeId)) {
             throw new RuntimeException("하나의 상점에 한사람 당 한개의 리뷰만 작성 가능");
         }

--- a/src/main/java/wad/seoul_nolgoat/service/review/ReviewService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/review/ReviewService.java
@@ -9,12 +9,14 @@ import wad.seoul_nolgoat.domain.store.Store;
 import wad.seoul_nolgoat.domain.store.StoreRepository;
 import wad.seoul_nolgoat.domain.user.User;
 import wad.seoul_nolgoat.domain.user.UserRepository;
+import wad.seoul_nolgoat.service.store.StoreService;
 import wad.seoul_nolgoat.util.mapper.ReviewMapper;
 import wad.seoul_nolgoat.web.review.dto.request.ReviewSaveDto;
 import wad.seoul_nolgoat.web.review.dto.request.ReviewUpdateDto;
 import wad.seoul_nolgoat.web.review.dto.response.ReviewDetailsForUserDto;
 
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
@@ -23,11 +25,20 @@ public class ReviewService {
     private final ReviewRepository reviewRepository;
     private final UserRepository userRepository;
     private final StoreRepository storeRepository;
+    private final StoreService storeService;
 
     public Long save(
             Long userId,
             Long storeId,
+            Optional<String> optionalImageUrl,
             ReviewSaveDto reviewSaveDto) {
+//        if (reviewRepository.existsByUserIdAndStoreId(userId, storeId)) {
+//            throw new RuntimeException("하나의 상점에 한사람 당 한개의 리뷰만 작성 가능");
+//        }
+
+        // accommodation averageGrade 업데이트
+        storeService.updateAverageGradeOnReviewAdd(storeId, reviewSaveDto.getGrade());
+
         User user = userRepository.findById(userId).get();
         Store store = storeRepository.findById(storeId).get();
 
@@ -35,6 +46,7 @@ public class ReviewService {
                 ReviewMapper.toEntity(
                         user,
                         store,
+                        optionalImageUrl,
                         reviewSaveDto
                 )
         ).getId();

--- a/src/main/java/wad/seoul_nolgoat/service/review/ReviewService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/review/ReviewService.java
@@ -9,6 +9,7 @@ import wad.seoul_nolgoat.domain.store.Store;
 import wad.seoul_nolgoat.domain.store.StoreRepository;
 import wad.seoul_nolgoat.domain.user.User;
 import wad.seoul_nolgoat.domain.user.UserRepository;
+import wad.seoul_nolgoat.service.s3.S3Service;
 import wad.seoul_nolgoat.service.store.StoreService;
 import wad.seoul_nolgoat.util.mapper.ReviewMapper;
 import wad.seoul_nolgoat.web.review.dto.request.ReviewSaveDto;
@@ -26,6 +27,7 @@ public class ReviewService {
     private final UserRepository userRepository;
     private final StoreRepository storeRepository;
     private final StoreService storeService;
+    private final S3Service s3Service;
 
     public Long save(
             Long userId,
@@ -68,6 +70,14 @@ public class ReviewService {
 
     public void deleteById(Long reviewId) {
         Review review = reviewRepository.findById(reviewId).get();
+
+        // accommodation averageGrade 업데이트
+        storeService.updateAverageGradeOnReviewDelete(review.getStore().getId(), review.getGrade());
+        // s3 이미지 파일 삭제
+        if (review.hasImageUrl()) {
+            s3Service.deleteFile(review.getImageUrl());
+        }
+
         review.delete();
         reviewRepository.deleteById(reviewId);
     }

--- a/src/main/java/wad/seoul_nolgoat/service/s3/S3Service.java
+++ b/src/main/java/wad/seoul_nolgoat/service/s3/S3Service.java
@@ -8,6 +8,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -29,6 +32,19 @@ public class S3Service {
 
         amazonS3.putObject(bucket, filename, multipartFile.getInputStream(), metadata);
         return amazonS3.getUrl(bucket, filename).toString();
+    }
+
+    public void deleteFile(String fileUrl) {
+        try {
+            URL url = new URL(fileUrl);
+            String path = url.getPath();
+            String key = path.substring(1);
+            String decodedKey = URLDecoder.decode(key, StandardCharsets.UTF_8); // 한글 또는 특수문자가 있는 경우를 위해
+
+            amazonS3.deleteObject(bucket, decodedKey);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to delete file from S3: " + fileUrl, e);
+        }
     }
 
     private String generateFileName(String originalFilename) {

--- a/src/main/java/wad/seoul_nolgoat/service/s3/S3Service.java
+++ b/src/main/java/wad/seoul_nolgoat/service/s3/S3Service.java
@@ -1,0 +1,31 @@
+package wad.seoul_nolgoat.service.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public String saveFile(MultipartFile multipartFile) throws IOException {
+        String filename = multipartFile.getOriginalFilename();
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(multipartFile.getSize());
+        metadata.setContentType(multipartFile.getContentType());
+
+        amazonS3.putObject(bucket, filename, multipartFile.getInputStream(), metadata);
+        return amazonS3.getUrl(bucket, filename).toString();
+    }
+}

--- a/src/main/java/wad/seoul_nolgoat/service/s3/S3Service.java
+++ b/src/main/java/wad/seoul_nolgoat/service/s3/S3Service.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.Objects;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -19,7 +21,7 @@ public class S3Service {
     private String bucket;
 
     public String saveFile(MultipartFile multipartFile) throws IOException {
-        String filename = multipartFile.getOriginalFilename();
+        String filename = generateFileName(Objects.requireNonNull(multipartFile.getOriginalFilename()));
 
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentLength(multipartFile.getSize());
@@ -27,5 +29,9 @@ public class S3Service {
 
         amazonS3.putObject(bucket, filename, multipartFile.getInputStream(), metadata);
         return amazonS3.getUrl(bucket, filename).toString();
+    }
+
+    private String generateFileName(String originalFilename) {
+        return UUID.randomUUID() + "-" + originalFilename.replace(" ", "_");
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/service/store/StoreService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/store/StoreService.java
@@ -43,4 +43,15 @@ public class StoreService {
         Store store = storeRepository.findById(storeId).get();
         store.delete();
     }
+
+    // Review 추가시 Accommodation averageGrade 업데이트
+    @Transactional
+    public void updateAverageGradeOnReviewAdd(Long storeId, double addedGrade) {
+        Store store = storeRepository.findById(storeId).get();
+        double previousAverageGrade = store.getNolgoatAverageGrade();
+        int reviewCount = store.getReviews().size();
+
+        double updatedAverageGrade = (previousAverageGrade * reviewCount + addedGrade) / (reviewCount + 1);
+        storeRepository.updateNolgoatAverageGrade(storeId, updatedAverageGrade);
+    }
 }

--- a/src/main/java/wad/seoul_nolgoat/service/store/StoreService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/store/StoreService.java
@@ -54,4 +54,31 @@ public class StoreService {
         double updatedAverageGrade = (previousAverageGrade * reviewCount + addedGrade) / (reviewCount + 1);
         storeRepository.updateNolgoatAverageGrade(storeId, updatedAverageGrade);
     }
+
+    // Review 업데이트시 Accommodation averageGrade 업데이트
+    @Transactional
+    public void updateAverageGradeOnReviewUpdate(Long storeId, double gradeDifference) {
+        Store store = storeRepository.findById(storeId).get();
+        double previousAverageGrade = store.getNolgoatAverageGrade();
+        int reviewCount = store.getReviews().size();
+
+        double updatedAverageGrade = (previousAverageGrade * reviewCount + gradeDifference) / reviewCount;
+        storeRepository.updateNolgoatAverageGrade(storeId, updatedAverageGrade);
+    }
+
+    // Review 삭제시 Accommodation averageGrade 업데이트
+    @Transactional
+    public void updateAverageGradeOnReviewDelete(Long storeId, double deletedGrade) {
+        Store store = storeRepository.findById(storeId).get();
+        double previousAverageGrade = store.getNolgoatAverageGrade();
+        int reviewCount = store.getReviews().size();
+
+        if (reviewCount == 1) {
+            storeRepository.updateNolgoatAverageGrade(storeId, 0);
+            return;
+        }
+
+        double updatedAverageGrade = (previousAverageGrade * reviewCount - deletedGrade) / (reviewCount - 1);
+        storeRepository.updateNolgoatAverageGrade(storeId, updatedAverageGrade);
+    }
 }

--- a/src/main/java/wad/seoul_nolgoat/util/DateTimeUtil.java
+++ b/src/main/java/wad/seoul_nolgoat/util/DateTimeUtil.java
@@ -1,0 +1,13 @@
+package wad.seoul_nolgoat.util;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class DateTimeUtil {
+
+    // LocalDateTime을 "yyyy-MM-dd" 형식의 문자열로 변환
+    public static String formatDate(LocalDateTime dateTime) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+        return dateTime.format(formatter);
+    }
+}

--- a/src/main/java/wad/seoul_nolgoat/util/mapper/ReviewMapper.java
+++ b/src/main/java/wad/seoul_nolgoat/util/mapper/ReviewMapper.java
@@ -7,12 +7,25 @@ import wad.seoul_nolgoat.web.review.dto.request.ReviewSaveDto;
 import wad.seoul_nolgoat.web.review.dto.response.ReviewDetailsForStoreDto;
 import wad.seoul_nolgoat.web.review.dto.response.ReviewDetailsForUserDto;
 
+import java.util.Optional;
+
 public class ReviewMapper {
 
     public static Review toEntity(
             User user,
             Store store,
+            Optional<String> optionalImageUrl,
             ReviewSaveDto reviewSaveDto) {
+        if (optionalImageUrl.isPresent()) {
+            return new Review(
+                    reviewSaveDto.getGrade(),
+                    reviewSaveDto.getContent(),
+                    optionalImageUrl.get(),
+                    user,
+                    store
+            );
+        }
+
         return new Review(
                 reviewSaveDto.getGrade(),
                 reviewSaveDto.getContent(),

--- a/src/main/java/wad/seoul_nolgoat/util/mapper/ReviewMapper.java
+++ b/src/main/java/wad/seoul_nolgoat/util/mapper/ReviewMapper.java
@@ -9,6 +9,8 @@ import wad.seoul_nolgoat.web.review.dto.response.ReviewDetailsForUserDto;
 
 import java.util.Optional;
 
+import static wad.seoul_nolgoat.util.DateTimeUtil.formatDate;
+
 public class ReviewMapper {
 
     public static Review toEntity(
@@ -38,6 +40,7 @@ public class ReviewMapper {
         return new ReviewDetailsForUserDto(
                 review.getGrade(),
                 review.getContent(),
+                review.getImageUrl(),
                 review.getStore().getId(),
                 review.getStore().getName()
         );
@@ -48,8 +51,11 @@ public class ReviewMapper {
                 review.getId(),
                 review.getGrade(),
                 review.getContent(),
+                review.getImageUrl(),
+                review.getUser().getId(),
                 review.getUser().getNickname(),
-                review.getUser().getProfileImage()
+                review.getUser().getProfileImage(),
+                formatDate(review.getCreatedDate())
         );
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/util/mapper/ReviewMapper.java
+++ b/src/main/java/wad/seoul_nolgoat/util/mapper/ReviewMapper.java
@@ -17,7 +17,8 @@ public class ReviewMapper {
             User user,
             Store store,
             Optional<String> optionalImageUrl,
-            ReviewSaveDto reviewSaveDto) {
+            ReviewSaveDto reviewSaveDto
+    ) {
         if (optionalImageUrl.isPresent()) {
             return new Review(
                     reviewSaveDto.getGrade(),

--- a/src/main/java/wad/seoul_nolgoat/util/mapper/UserMapper.java
+++ b/src/main/java/wad/seoul_nolgoat/util/mapper/UserMapper.java
@@ -30,6 +30,7 @@ public class UserMapper {
 
     public static UserProfileDto toUserProfileDto(User user) {
         return new UserProfileDto(
+                user.getId(),
                 user.getLoginId(),
                 user.getNickname(),
                 user.getProfileImage()

--- a/src/main/java/wad/seoul_nolgoat/web/auth/dto/response/UserProfileDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/auth/dto/response/UserProfileDto.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class UserProfileDto {
 
+    private final Long userId;
     private final String loginId;
     private final String nickname;
     private final String profileImage;

--- a/src/main/java/wad/seoul_nolgoat/web/review/ReviewController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/review/ReviewController.java
@@ -6,12 +6,10 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.util.UriComponentsBuilder;
 import wad.seoul_nolgoat.service.review.ReviewService;
-import wad.seoul_nolgoat.service.s3.S3Service;
 import wad.seoul_nolgoat.web.review.dto.request.ReviewSaveDto;
 import wad.seoul_nolgoat.web.review.dto.request.ReviewUpdateDto;
 import wad.seoul_nolgoat.web.review.dto.response.ReviewDetailsForUserDto;
 
-import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 import java.util.Optional;
@@ -22,7 +20,6 @@ import java.util.Optional;
 public class ReviewController {
 
     private final ReviewService reviewService;
-    private final S3Service s3Service;
 
     @PostMapping("/{userId}/{storeId}")
     public ResponseEntity<Void> createReview(
@@ -31,19 +28,10 @@ public class ReviewController {
             @RequestPart(value = "file", required = false) MultipartFile file,
             @RequestPart("review") ReviewSaveDto reviewSaveDto,
             UriComponentsBuilder uriComponentsBuilder) {
-        Optional<String> optionalImageUrl = Optional.empty();
-        if (file != null && !file.isEmpty()) {
-            try {
-                optionalImageUrl = Optional.of(s3Service.saveFile(file));
-            } catch (IOException e) {
-                throw new RuntimeException();
-            }
-        }
-
         Long reviewId = reviewService.save(
                 userId,
                 storeId,
-                optionalImageUrl,
+                Optional.ofNullable(file),
                 reviewSaveDto
         );
         URI location = uriComponentsBuilder.path("/api/reviews/{reviewId}")

--- a/src/main/java/wad/seoul_nolgoat/web/review/ReviewController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/review/ReviewController.java
@@ -3,14 +3,18 @@ package wad.seoul_nolgoat.web.review;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.util.UriComponentsBuilder;
 import wad.seoul_nolgoat.service.review.ReviewService;
+import wad.seoul_nolgoat.service.s3.S3Service;
 import wad.seoul_nolgoat.web.review.dto.request.ReviewSaveDto;
 import wad.seoul_nolgoat.web.review.dto.request.ReviewUpdateDto;
 import wad.seoul_nolgoat.web.review.dto.response.ReviewDetailsForUserDto;
 
+import java.io.IOException;
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/reviews")
@@ -18,16 +22,28 @@ import java.util.List;
 public class ReviewController {
 
     private final ReviewService reviewService;
+    private final S3Service s3Service;
 
     @PostMapping("/{userId}/{storeId}")
     public ResponseEntity<Void> createReview(
             @PathVariable Long userId,
             @PathVariable Long storeId,
-            @RequestBody ReviewSaveDto reviewSaveDto,
+            @RequestPart(value = "file", required = false) MultipartFile file,
+            @RequestPart("review") ReviewSaveDto reviewSaveDto,
             UriComponentsBuilder uriComponentsBuilder) {
+        Optional<String> optionalImageUrl = Optional.empty();
+        if (file != null && !file.isEmpty()) {
+            try {
+                optionalImageUrl = Optional.of(s3Service.saveFile(file));
+            } catch (IOException e) {
+                throw new RuntimeException();
+            }
+        }
+
         Long reviewId = reviewService.save(
                 userId,
                 storeId,
+                optionalImageUrl,
                 reviewSaveDto
         );
         URI location = uriComponentsBuilder.path("/api/reviews/{reviewId}")
@@ -45,6 +61,7 @@ public class ReviewController {
                 .ok(reviewService.findByUserId(userId));
     }
 
+    // 현재 사용하지 않음
     @PutMapping("/{reviewId}")
     public ResponseEntity<Void> update(@PathVariable Long reviewId, @RequestBody ReviewUpdateDto reviewUpdateDto) {
         reviewService.update(reviewId, reviewUpdateDto);

--- a/src/main/java/wad/seoul_nolgoat/web/review/ReviewController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/review/ReviewController.java
@@ -27,7 +27,8 @@ public class ReviewController {
             @PathVariable Long storeId,
             @RequestPart(value = "file", required = false) MultipartFile file,
             @RequestPart("review") ReviewSaveDto reviewSaveDto,
-            UriComponentsBuilder uriComponentsBuilder) {
+            UriComponentsBuilder uriComponentsBuilder
+    ) {
         Long reviewId = reviewService.save(
                 userId,
                 storeId,

--- a/src/main/java/wad/seoul_nolgoat/web/review/dto/request/ReviewSaveDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/review/dto/request/ReviewSaveDto.java
@@ -7,6 +7,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ReviewSaveDto {
 
-    private final double grade;
+    private final int grade;
     private final String content;
 }

--- a/src/main/java/wad/seoul_nolgoat/web/review/dto/request/ReviewUpdateDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/review/dto/request/ReviewUpdateDto.java
@@ -7,6 +7,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ReviewUpdateDto {
 
-    private final double grade;
+    private final int grade;
     private final String content;
 }

--- a/src/main/java/wad/seoul_nolgoat/web/review/dto/response/ReviewDetailsForStoreDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/review/dto/response/ReviewDetailsForStoreDto.java
@@ -10,6 +10,9 @@ public class ReviewDetailsForStoreDto {
     private final Long id;
     private final double grade;
     private final String content;
+    private final String imageUrl;
+    private final Long userId;
     private final String userNickname;
     private final String userProfileImage;
+    private final String createDate;
 }

--- a/src/main/java/wad/seoul_nolgoat/web/review/dto/response/ReviewDetailsForStoreDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/review/dto/response/ReviewDetailsForStoreDto.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 public class ReviewDetailsForStoreDto {
 
     private final Long id;
-    private final double grade;
+    private final int grade;
     private final String content;
     private final String imageUrl;
     private final Long userId;

--- a/src/main/java/wad/seoul_nolgoat/web/review/dto/response/ReviewDetailsForUserDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/review/dto/response/ReviewDetailsForUserDto.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ReviewDetailsForUserDto {
 
-    private final double grade;
+    private final int grade;
     private final String content;
     private final String imageUrl;
     private final Long storeId;

--- a/src/main/java/wad/seoul_nolgoat/web/review/dto/response/ReviewDetailsForUserDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/review/dto/response/ReviewDetailsForUserDto.java
@@ -9,6 +9,7 @@ public class ReviewDetailsForUserDto {
 
     private final double grade;
     private final String content;
+    private final String imageUrl;
     private final Long storeId;
     private final String storeName;
 }

--- a/src/main/java/wad/seoul_nolgoat/web/search/dto/request/SearchConditionDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/search/dto/request/SearchConditionDto.java
@@ -1,17 +1,30 @@
 package wad.seoul_nolgoat.web.search.dto.request;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import wad.seoul_nolgoat.web.search.dto.CoordinateDto;
 
+import java.util.Arrays;
 import java.util.List;
 
 @Getter
-@RequiredArgsConstructor
 public class SearchConditionDto {
+
+    private static final String SPLIT_DELIMITER = ";";
 
     private final CoordinateDto startCoordinate;
     private final double radiusRange;
     private final String criteria;
-    private final List<String> categories;
+    private List<String> categories;
+
+    public SearchConditionDto(CoordinateDto startCoordinate, double radiusRange, String criteria, String categories) {
+        this.startCoordinate = startCoordinate;
+        this.radiusRange = radiusRange;
+        this.criteria = criteria;
+        this.setCategories(categories); // 문자열을 받아 리스트로 변환
+    }
+
+    // 클라이언트에서 api를 호출할 때: 쉼표가 포함되는 값이 있다(ex. 육류,고기). 쉼표를 구분자로 하여 categories를 입력하면 값에 포함되는 쉼표가 구분자로 인식되어 오류가 발생할 수도 있다(ex. "육류,고기"를 "육류""고기"로 인식할 수도 있음). 때문에 구분자로 ; 를 이용하였다.
+    private void setCategories(String categories) {
+        this.categories = Arrays.asList(categories.split(SPLIT_DELIMITER));
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,3 +9,4 @@ spring:
       - t-config.yml
       - oauth2-config.yml
       - jwt-config.yml
+      - s3-config.yml

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,3 +10,4 @@ spring:
       - oauth2-config.yml
       - jwt-config.yml
       - s3-config.yml
+      - multipart-config.yml


### PR DESCRIPTION
### Review 작성 시 이미지 업로드 기능
#### 리뷰 작성 (이미지를 첨부 했다면)
- 사용자가 첨부한 이미지를(MultipartFile) AWS S3에 저장
- S3에 저장한 이미지 링크를 DB 에 저장

#### 리뷰 삭제 (이미지가 포함된 리뷰이면)
- 이미지 링크를 통해 S3에 저장된 파일 삭제
- DB에 이미지 링크 삭제

### SearchConditionDto의 categories 필드 구분자 수정
카테고리 중 쉼표를 포함한 값이 있어서 기본 구분자인 쉼표를 사용하면 의도하지 않은 결과가 나온다. (ex. "고기,육류"라는 카테고리 하나를 컨트롤러가 받으면 categories에 "고기", "육류" 두개의 카테고리로 저장된다) 이를 해결하기 위해 프론트엔드에서 카테고리를 쉼표가 아닌 ; 로 구분해서 요청을 보낸다 (ex. "고기,육류;한식;중식"). 때문에 SearchConditionDto에서 카테고리를 받을 때 ;로 구분하여 받아야 한다.
