### PR TITLE
Refactor/reduce case count at rating combinations

### DIFF
--- a/src/main/java/wad/seoul_nolgoat/domain/store/StoreRepositoryCustomImpl.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/store/StoreRepositoryCustomImpl.java
@@ -86,6 +86,17 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
             double radiusRange,
             String category
     ) {
+        Double baseKakaoAverageGrade = jpaQueryFactory.select(store.kakaoAverageGrade)
+                .from(store)
+                .where(
+                        calculateHaversineDistance(startCoordinate).loe(radiusRange),
+                        store.category.contains(category)
+                )
+                .orderBy(store.kakaoAverageGrade.desc())
+                .limit(1)
+                .offset(9)
+                .fetchOne();
+
         return Collections.unmodifiableList(
                 jpaQueryFactory.select(
                                 Projections.constructor(
@@ -105,7 +116,8 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
                         .from(store)
                         .where(
                                 calculateHaversineDistance(startCoordinate).loe(radiusRange),
-                                store.category.contains(category)
+                                store.category.contains(category),
+                                store.kakaoAverageGrade.goe(baseKakaoAverageGrade)
                         )
                         .fetch()
         );
@@ -117,6 +129,17 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
             double radiusRange,
             StoreType storeType
     ) {
+        Double baseKakaoAverageGrade = jpaQueryFactory.select(store.kakaoAverageGrade)
+                .from(store)
+                .where(
+                        calculateHaversineDistance(startCoordinate).loe(radiusRange),
+                        store.storeType.eq(storeType)
+                )
+                .orderBy(store.kakaoAverageGrade.desc())
+                .limit(1)
+                .offset(9)
+                .fetchOne();
+
         return Collections.unmodifiableList(
                 jpaQueryFactory.select(
                                 Projections.constructor(
@@ -136,7 +159,8 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
                         .from(store)
                         .where(
                                 calculateHaversineDistance(startCoordinate).loe(radiusRange),
-                                store.storeType.eq(storeType)
+                                store.storeType.eq(storeType),
+                                store.kakaoAverageGrade.goe(baseKakaoAverageGrade)
                         )
                         .fetch()
         );
@@ -148,6 +172,17 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
             double radiusRange,
             String category
     ) {
+        Double baseNolgoatAverageGrade = jpaQueryFactory.select(store.nolgoatAverageGrade)
+                .from(store)
+                .where(
+                        calculateHaversineDistance(startCoordinate).loe(radiusRange),
+                        store.category.contains(category)
+                )
+                .orderBy(store.nolgoatAverageGrade.desc())
+                .limit(1)
+                .offset(9)
+                .fetchOne();
+
         return Collections.unmodifiableList(
                 jpaQueryFactory.select(
                                 Projections.constructor(
@@ -167,7 +202,8 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
                         .from(store)
                         .where(
                                 calculateHaversineDistance(startCoordinate).loe(radiusRange),
-                                store.category.contains(category)
+                                store.category.contains(category),
+                                store.nolgoatAverageGrade.goe(baseNolgoatAverageGrade)
                         )
                         .fetch()
         );
@@ -179,6 +215,17 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
             double radiusRange,
             StoreType storeType
     ) {
+        Double baseNolgoatAverageGrade = jpaQueryFactory.select(store.nolgoatAverageGrade)
+                .from(store)
+                .where(
+                        calculateHaversineDistance(startCoordinate).loe(radiusRange),
+                        store.storeType.eq(storeType)
+                )
+                .orderBy(store.nolgoatAverageGrade.desc())
+                .limit(1)
+                .offset(9)
+                .fetchOne();
+
         return Collections.unmodifiableList(
                 jpaQueryFactory.select(
                                 Projections.constructor(
@@ -198,7 +245,8 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
                         .from(store)
                         .where(
                                 calculateHaversineDistance(startCoordinate).loe(radiusRange),
-                                store.storeType.eq(storeType)
+                                store.storeType.eq(storeType),
+                                store.nolgoatAverageGrade.goe(baseNolgoatAverageGrade)
                         )
                         .fetch()
         );

--- a/src/main/java/wad/seoul_nolgoat/service/search/dto/GradeSortCombinationDto.java
+++ b/src/main/java/wad/seoul_nolgoat/service/search/dto/GradeSortCombinationDto.java
@@ -9,6 +9,7 @@ public class GradeSortCombinationDto {
     private StoreForGradeSortDto firstStore;
     private StoreForGradeSortDto secondStore;
     private StoreForGradeSortDto thirdStore;
+    private final double totalGrade;
     private final int totalRounds;
 
     public GradeSortCombinationDto(
@@ -20,16 +21,19 @@ public class GradeSortCombinationDto {
         this.secondStore = secondStore;
         this.thirdStore = thirdStore;
         this.totalRounds = SearchService.THREE_ROUND;
+        this.totalGrade = firstStore.getAverageGrade() + secondStore.getAverageGrade() + thirdStore.getAverageGrade();
     }
 
     public GradeSortCombinationDto(StoreForGradeSortDto firstStore, StoreForGradeSortDto secondStore) {
         this.firstStore = firstStore;
         this.secondStore = secondStore;
         this.totalRounds = SearchService.TWO_ROUND;
+        this.totalGrade = firstStore.getAverageGrade() + secondStore.getAverageGrade();
     }
 
     public GradeSortCombinationDto(StoreForGradeSortDto firstStore) {
         this.firstStore = firstStore;
         this.totalRounds = SearchService.ONE_ROUND;
+        this.totalGrade = firstStore.getAverageGrade();
     }
 }


### PR DESCRIPTION
## ✔️ 작업 내용

- [x] 차수마다 기준이 되는 순번(10번째)의 평점 이상인 가게들만 가져오도록 수정했습니다. 
(2번의 쿼리가 발생합니다. => 기준이 되는 평점 조회 + 해당 평점 이상인 가게들 조회)
- [x] 특정 가게가 상위권에 쏠리지 않도록 하기 위해 총 평점별로 그룹화하고, 그룹 내에서는 순서를 무작위로 섞도록 했습니다.

## 📋 세부 사항

로직 변경에 따른 성능 개선

## 🔒 닫을 이슈

close #24

## ➕ 기타 사항

- 조회 성능 개선을 위해 Store 테이블에 복합 컬럼 인덱스(kakao_average_grade, category / nolgoat_average_grade, category)를 생성했습니다.
- nolgoat 평점은 아직 대부분 0점이라 기준 평점을 정해서 필터링해도 많은 수의 가게가 조회되는데, 이에 대한 방안이 필요합니다.