### PR TITLE
인증 보안 강화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 /src/main/resources/seoul-config.yml
 /src/main/resources/t-config.yml
 /src/main/resources/oauth2-config.yml
-/src/main/resources/jwt-config.yml
+/src/main/resources/authorization-config.yml
 /src/main/resources/s3-config.yml
 /src/main/resources/multipart-config.yml
 /src/main/resources/app-urls.yml

--- a/src/main/java/wad/seoul_nolgoat/auth/jwt/JwtFilter.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/jwt/JwtFilter.java
@@ -19,6 +19,8 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 
+import static wad.seoul_nolgoat.auth.service.AuthService.AUTHORIZATION_HEADER;
+
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
 
@@ -29,7 +31,7 @@ public class JwtFilter extends OncePerRequestFilter {
         // 헤더, 토큰 검증
         String accessToken;
         try {
-            String authorizationHeader = request.getHeader(JwtProvider.AUTHORIZATION_HEADER);
+            String authorizationHeader = request.getHeader(AUTHORIZATION_HEADER);
             authService.verifyAuthorizationHeader(authorizationHeader);
             accessToken = authorizationHeader.split(" ")[1];
             authService.verifyAccessToken(accessToken);

--- a/src/main/java/wad/seoul_nolgoat/auth/jwt/JwtProvider.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/jwt/JwtProvider.java
@@ -13,14 +13,12 @@ import java.util.Date;
 @Service
 public class JwtProvider {
 
-    public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final Long REFRESH_TOKEN_EXPIRATION_TIME = 14 * 24 * 60 * 60 * 1000L; // 14 days
     public static final Long ACCESS_TOKEN_EXPIRATION_TIME = 60 * 60 * 1000L; // 1 hour
     public static final String CLAIM_TYPE = "type";
     public static final String CLAIM_TYPE_REFRESH = "refresh";
     public static final String CLAIM_TYPE_ACCESS = "access";
-    public static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
-
+    
     private final SecretKey secretKey;
     private final String domain;
 

--- a/src/main/java/wad/seoul_nolgoat/auth/oauth2/CustomSuccessHandler.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/oauth2/CustomSuccessHandler.java
@@ -33,11 +33,11 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         String successBaseUrl = frontendBaseUrl + SUCCESS_URL;
         String url = String.format(
-                "%s?access=%s&refresh=%s",
+                "%s?access=%s",
                 successBaseUrl,
-                URLEncoder.encode(accessToken, CHARSET),
-                URLEncoder.encode(refreshToken, CHARSET)
+                URLEncoder.encode(accessToken, CHARSET)
         );
+        response.addCookie(authService.createRefreshTokenCookie(refreshToken));
         response.sendRedirect(url);
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/auth/service/AuthService.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/service/AuthService.java
@@ -18,6 +18,9 @@ import static wad.seoul_nolgoat.exception.ErrorCode.*;
 @Service
 public class AuthService {
 
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+
     private static final String BEARER_PREFIX = "Bearer ";
     private static final int REFRESH_TOKEN_COOKIE_EXPIRATION_TIME = 14 * 24 * 60 * 60; // 14 days
 

--- a/src/main/java/wad/seoul_nolgoat/auth/service/AuthService.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/service/AuthService.java
@@ -20,6 +20,7 @@ public class AuthService {
 
     public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+    public static final String CSRF_PROTECTION_UUID_HEADER = "Csrf-Protection-Uuid";
 
     private static final String BEARER_PREFIX = "Bearer ";
     private static final int REFRESH_TOKEN_COOKIE_EXPIRATION_TIME = 14 * 24 * 60 * 60; // 14 days

--- a/src/main/java/wad/seoul_nolgoat/auth/service/AuthService.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/service/AuthService.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.JwtException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import wad.seoul_nolgoat.auth.jwt.JwtProvider;
 import wad.seoul_nolgoat.exception.ApiException;
@@ -27,6 +28,9 @@ public class AuthService {
 
     private final JwtProvider jwtProvider;
     private final TokenService tokenService;
+
+    @Value("${spring.csrf.protection.uuid}")
+    private String csrfProtectionUuid;
 
     // Refresh 토큰 생성 및 저장
     public String createRefreshToken(String loginId) {
@@ -97,6 +101,12 @@ public class AuthService {
             throw new ApiException(TOKEN_EXPIRED);
         } catch (JwtException e) { // ExpiredJwtException을 제외한 나머지 JwtException 처리
             throw new ApiException(INVALID_TOKEN_FORMAT);
+        }
+    }
+
+    public void verifyCsrfProtectionUuid(String csrfProtectionUuid) {
+        if (!this.csrfProtectionUuid.equals(csrfProtectionUuid)) {
+            throw new ApiException(INVALID_CSRF_PROTECTION_UUID);
         }
     }
 

--- a/src/main/java/wad/seoul_nolgoat/auth/service/AuthService.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/service/AuthService.java
@@ -19,6 +19,7 @@ import static wad.seoul_nolgoat.exception.ErrorCode.*;
 public class AuthService {
 
     private static final String BEARER_PREFIX = "Bearer ";
+    private static final int REFRESH_TOKEN_COOKIE_EXPIRATION_TIME = 14 * 24 * 60 * 60; // 14 days
 
     private final JwtProvider jwtProvider;
     private final TokenService tokenService;
@@ -135,6 +136,16 @@ public class AuthService {
                 accessToken,
                 jwtProvider.getExpiration(accessToken)
         );
+    }
+
+    // Refresh 토큰을 쿠키에 저장
+    public Cookie createRefreshTokenCookie(String refreshToken) {
+        Cookie refreshTokenCookie = new Cookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken);
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setSecure(true);
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setMaxAge(REFRESH_TOKEN_COOKIE_EXPIRATION_TIME);
+        return refreshTokenCookie;
     }
 
     // Refresh 토큰 만료 시, 쿠키 삭제

--- a/src/main/java/wad/seoul_nolgoat/auth/service/TokenService.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/service/TokenService.java
@@ -5,6 +5,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 @RequiredArgsConstructor
 @Service
@@ -23,7 +24,7 @@ public class TokenService {
         // 설정한 유효 기간까지 시간이 얼마나 남았는지 계산
         long remainingTime = expirationDate.getTime() - System.currentTimeMillis();
         redisTemplate.opsForValue()
-                .set(key, value, remainingTime);
+                .set(key, value, remainingTime, TimeUnit.MILLISECONDS);
     }
 
     public void deleteToken(String key) {

--- a/src/main/java/wad/seoul_nolgoat/auth/web/AuthController.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/web/AuthController.java
@@ -10,8 +10,8 @@ import wad.seoul_nolgoat.auth.service.AuthService;
 import wad.seoul_nolgoat.auth.web.dto.response.UserProfileDto;
 import wad.seoul_nolgoat.service.user.UserService;
 
-import static wad.seoul_nolgoat.auth.jwt.JwtProvider.AUTHORIZATION_HEADER;
-import static wad.seoul_nolgoat.auth.jwt.JwtProvider.REFRESH_TOKEN_COOKIE_NAME;
+import static wad.seoul_nolgoat.auth.service.AuthService.AUTHORIZATION_HEADER;
+import static wad.seoul_nolgoat.auth.service.AuthService.REFRESH_TOKEN_COOKIE_NAME;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/auths")

--- a/src/main/java/wad/seoul_nolgoat/config/SecurityConfig.java
+++ b/src/main/java/wad/seoul_nolgoat/config/SecurityConfig.java
@@ -73,7 +73,6 @@ public class SecurityConfig {
         configuration.setAllowedOrigins(List.of(frontendBaseUrl));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
-        configuration.setExposedHeaders(List.of("Authorization", "Refresh"));
         configuration.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/wad/seoul_nolgoat/exception/ErrorCode.java
+++ b/src/main/java/wad/seoul_nolgoat/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     MISSING_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "AUTH007", "Refresh 토큰 쿠키가 누락되었습니다."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH008", "저장소에 존재하지 않는 Refresh 토큰입니다."),
     ACCESS_TOKEN_BLACKLISTED(HttpStatus.UNAUTHORIZED, "AUTH009", "블랙리스트에 등록된 Access 토큰입니다."),
+    INVALID_CSRF_PROTECTION_UUID(HttpStatus.UNAUTHORIZED, "AUTH010", "유효하지 않은 CSRF Protection UUID입니다."),
 
     // 유저 관련
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER001", "존재하지 않는 유저입니다."),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
       - seoul-config.yml
       - t-config.yml
       - oauth2-config.yml
-      - jwt-config.yml
+      - authorization-config.yml
       - s3-config.yml
       - multipart-config.yml
       - app-urls.yml

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -23,6 +23,6 @@ spring:
     init:
       mode: always
 
-  logging:
-    level:
-      org.hibernate.sql: debug
+logging:
+  level:
+    org.hibernate.sql: debug


### PR DESCRIPTION
## ✔️ 작업 내용

- **Http-Only 사용**
  - 로그인 성공 시, `Http-Only` 설정이 적용된 쿠키에 `Refresh` 토큰을 저장하여 `JavaScript`를 통한 접근을 차단함으로써, `XSS` 공격 위험을 줄일 수 있습니다.
- **CSRF 검증용 UUID 활용**
  - `Refresh` 토큰이 필요한 요청(`토큰 재발급`, `로그아웃`) 시, 클라이언트는 요청 헤더 `Csrf-Protection-Uuid`에 미리 생성해 놓은 `UUID`를 포함하여 전송하고, 서버는 이를 검증함으로써 `CSRF` 공격 위험을 줄일 수 있습니다.

## 📋 요약

- `Refresh` 토큰을 `Http-Only` 쿠키에 저장하여 `XSS` 공격 위험을 줄였습니다.
- `UUID` 검증을 통해 `CSRF` 공격 위험을 줄였습니다.

## 🔒 관련 이슈

close #35

## ➕ 기타 사항