### PR TITLE
가능한 카테고리를 반환할 때 Enum 상수 이름을 반환하도록 수정

### DIFF
--- a/src/main/java/wad/seoul_nolgoat/domain/store/StoreCategory.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/store/StoreCategory.java
@@ -4,6 +4,7 @@ import wad.seoul_nolgoat.exception.ApiException;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import static wad.seoul_nolgoat.exception.ErrorCode.CATEGORY_NOT_FOUND;
 
@@ -108,6 +109,13 @@ public enum StoreCategory {
         } catch (IllegalArgumentException e) {
             throw new ApiException(CATEGORY_NOT_FOUND);
         }
+    }
+
+    public static Optional<String> findPrimaryCategoryName(String categoryName) {
+        return Arrays.stream(StoreCategory.values())
+                .filter(storeCategory -> storeCategory.categories.contains(categoryName))
+                .map(Enum::name)
+                .findFirst();
     }
 
     private List<String> getCategoryNames() {

--- a/src/main/java/wad/seoul_nolgoat/service/search/SearchService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/search/SearchService.java
@@ -15,10 +15,7 @@ import wad.seoul_nolgoat.web.search.dto.request.PossibleCategoriesConditionDto;
 import wad.seoul_nolgoat.web.search.dto.request.SearchConditionDto;
 import wad.seoul_nolgoat.web.search.dto.response.CombinationDto;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static wad.seoul_nolgoat.exception.ErrorCode.INVALID_GATHERING_ROUND;
@@ -75,7 +72,8 @@ public class SearchService {
         for (StoreForPossibleCategoriesDto untokenizedCategory : untokenizedCategories) {
             String[] tokens = untokenizedCategory.getCategory().replace(SPACE, EMPTY).split(DELIMITER);
             for (String token : tokens) {
-                possibleCategories.addAll(StoreCategory.findRelatedCategoryNames(token));
+                Optional<String> primaryCategory = StoreCategory.findPrimaryCategoryName(token);
+                primaryCategory.ifPresent(possibleCategories::add);
             }
         }
 


### PR DESCRIPTION
## ✔️ 작업 내용

-  특정 카테고리가 주어졌을 때, 그에 해당하는 대표 카테고리 Enum 상수 이름을 반환하는 메서드 구현
   - `findPrimaryCategoryName`   
   - 예외를 throw하지 않고 Optional로 반환한다

- 대표 카테고리를 모을 때 존재하지 않는 카테고리여도 예외를 throw 하지 않고 넘어가도록 수정 
   - `SearchService / searchPossibleCategories 메서드 `
      -  `findRelatedCategoryNames` ->  `findPrimaryCategoryName` 메서드로 수정
   - Optional 사용

## 📋 요약

## 🔒 관련 이슈

close #43

## ➕ 기타 사항