### PR TITLE
회원 탈퇴 시, 소셜 로그인 제공자와의 계정 연결 해제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,12 @@ repositories {
     mavenCentral()
 }
 
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:2023.0.1"
+    }
+}
+
 dependencies {
     // implementation dependencies
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -45,6 +51,7 @@ dependencies {
 
     // spring cloud
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.0'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
     // compile-only dependencies
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/wad/seoul_nolgoat/SeoulNolgoatApplication.java
+++ b/src/main/java/wad/seoul_nolgoat/SeoulNolgoatApplication.java
@@ -2,10 +2,12 @@ package wad.seoul_nolgoat;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.web.client.RestTemplate;
 
+@EnableFeignClients
 @EnableJpaAuditing
 @SpringBootApplication
 public class SeoulNolgoatApplication {

--- a/src/main/java/wad/seoul_nolgoat/auth/AuthUrlManager.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/AuthUrlManager.java
@@ -9,6 +9,7 @@ public class AuthUrlManager {
         return new RequestMatcher[]{
                 new AntPathRequestMatcher("/api/auths/me"),
                 new AntPathRequestMatcher("/api/auths/logout"),
+                new AntPathRequestMatcher("/api/auths/user/delete"),
 
                 new AntPathRequestMatcher("/api/stores/**"),
 

--- a/src/main/java/wad/seoul_nolgoat/auth/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/oauth2/CustomOAuth2UserService.java
@@ -7,13 +7,13 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
-import wad.seoul_nolgoat.auth.oauth2.dto.*;
-import wad.seoul_nolgoat.domain.user.User;
-import wad.seoul_nolgoat.domain.user.UserRepository;
+import org.springframework.transaction.annotation.Transactional;
+import wad.seoul_nolgoat.auth.oauth2.dto.GoogleResponse;
+import wad.seoul_nolgoat.auth.oauth2.dto.KakaoResponse;
 import wad.seoul_nolgoat.exception.ApiException;
+import wad.seoul_nolgoat.service.user.UserService;
 
 import static wad.seoul_nolgoat.exception.ErrorCode.UNSUPPORTED_PROVIDER;
-import static wad.seoul_nolgoat.exception.ErrorCode.USER_NOT_FOUND;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -24,50 +24,21 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     public static final String GOOGLE = "google";
     public static final String PROVIDER_ID_DELIMITER = "_";
 
-    private final UserRepository userRepository;
+    private final UserService userService;
 
+    @Transactional
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         OAuth2User oAuth2User = super.loadUser(userRequest);
 
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
         if (registrationId.equals(KAKAO)) {
-            return processOAuth2User(new KakaoResponse(oAuth2User.getAttributes()));
+            return userService.processOAuth2User(new KakaoResponse(oAuth2User.getAttributes()));
         }
         if (registrationId.equals(GOOGLE)) {
-            return processOAuth2User(new GoogleResponse(oAuth2User.getAttributes()));
+            return userService.processOAuth2User(new GoogleResponse(oAuth2User.getAttributes()));
         }
         log.error("Unsupported OAuth2 provider: {}", registrationId);
         throw new ApiException(UNSUPPORTED_PROVIDER);
-    }
-
-    private OAuth2User processOAuth2User(OAuth2Response oAuth2Response) {
-        String uniqueProviderId = oAuth2Response.getProvider() + PROVIDER_ID_DELIMITER + oAuth2Response.getProviderId();
-        String nickname = oAuth2Response.getNickname();
-        String profileImage = oAuth2Response.getProfileImage();
-
-        if (!userRepository.existsByLoginId(uniqueProviderId)) {
-            userRepository.save(
-                    new User(
-                            uniqueProviderId,
-                            null,
-                            nickname,
-                            profileImage,
-                            null,
-                            null
-                    )
-            );
-            OAuth2UserDto oAuth2UserDto = new OAuth2UserDto(uniqueProviderId);
-            return new OAuth2UserImpl(oAuth2UserDto);
-        }
-        User user = userRepository.findByLoginId(uniqueProviderId)
-                .orElseThrow(() -> new ApiException(USER_NOT_FOUND));
-        user.update(
-                null,
-                nickname,
-                profileImage
-        );
-        OAuth2UserDto oAuth2UserDto = new OAuth2UserDto(uniqueProviderId);
-        return new OAuth2UserImpl(oAuth2UserDto);
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/auth/oauth2/OAuth2AuthorizationRequestResolverImpl.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/oauth2/OAuth2AuthorizationRequestResolverImpl.java
@@ -1,0 +1,54 @@
+package wad.seoul_nolgoat.auth.oauth2;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OAuth2AuthorizationRequestResolverImpl implements OAuth2AuthorizationRequestResolver {
+
+    private static final String AUTHORIZATION_REQUESTS_BASE_URI = "/oauth2/authorization";
+
+    private final DefaultOAuth2AuthorizationRequestResolver defaultResolver;
+
+    public OAuth2AuthorizationRequestResolverImpl(ClientRegistrationRepository clientRegistrationRepository) {
+        this.defaultResolver = new DefaultOAuth2AuthorizationRequestResolver(
+                clientRegistrationRepository,
+                AUTHORIZATION_REQUESTS_BASE_URI
+        );
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+        return customizeAuthorizationRequest(defaultResolver.resolve(request));
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
+        return customizeAuthorizationRequest(defaultResolver.resolve(request, clientRegistrationId));
+    }
+
+    private OAuth2AuthorizationRequest customizeAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest) {
+        if (authorizationRequest == null) {
+            return null;
+        }
+
+        Object registrationId = authorizationRequest.getAttribute("registration_id");
+
+        // 구글일 때만 Refresh 토큰을 받기 위해, 파라미터 추가
+        if (registrationId.equals("google")) {
+            return OAuth2AuthorizationRequest.from(authorizationRequest)
+                    .additionalParameters(params -> {
+                        params.put("prompt", "consent");
+                        params.put("access_type", "offline");
+                    })
+                    .build();
+        }
+
+        // 다른 제공자는 그대로 반환
+        return authorizationRequest;
+    }
+}

--- a/src/main/java/wad/seoul_nolgoat/auth/oauth2/RedisOAuth2AuthorizedClientService.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/oauth2/RedisOAuth2AuthorizedClientService.java
@@ -7,7 +7,7 @@ import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.OAuth2RefreshToken;
 import org.springframework.stereotype.Service;
-import wad.seoul_nolgoat.auth.service.TokenService;
+import wad.seoul_nolgoat.auth.service.RedisTokenService;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -17,7 +17,7 @@ import java.util.Date;
 @Service
 public class RedisOAuth2AuthorizedClientService implements OAuth2AuthorizedClientService {
 
-    private final TokenService tokenService;
+    private final RedisTokenService redisTokenService;
 
     @Override
     public <T extends OAuth2AuthorizedClient> T loadAuthorizedClient(String clientRegistrationId, String principalName) {
@@ -30,8 +30,8 @@ public class RedisOAuth2AuthorizedClientService implements OAuth2AuthorizedClien
         OAuth2RefreshToken refreshToken = authorizedClient.getRefreshToken();
         OAuth2AccessToken accessToken = authorizedClient.getAccessToken();
 
-        String key = TokenService.OAUTH2_REFRESH_TOKEN_PREFIX + loginId;
-        tokenService.saveToken(
+        String key = RedisTokenService.OAUTH2_REFRESH_TOKEN_PREFIX + loginId;
+        redisTokenService.saveToken(
                 key,
                 refreshToken.getTokenValue(),
                 Date.from(
@@ -42,8 +42,8 @@ public class RedisOAuth2AuthorizedClientService implements OAuth2AuthorizedClien
                 )
         );
 
-        key = TokenService.OAUTH2_ACCESS_TOKEN_PREFIX + loginId;
-        tokenService.saveToken(
+        key = RedisTokenService.OAUTH2_ACCESS_TOKEN_PREFIX + loginId;
+        redisTokenService.saveToken(
                 key,
                 accessToken.getTokenValue(),
                 Date.from(accessToken.getExpiresAt())

--- a/src/main/java/wad/seoul_nolgoat/auth/oauth2/RedisOAuth2AuthorizedClientService.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/oauth2/RedisOAuth2AuthorizedClientService.java
@@ -30,7 +30,7 @@ public class RedisOAuth2AuthorizedClientService implements OAuth2AuthorizedClien
         OAuth2RefreshToken refreshToken = authorizedClient.getRefreshToken();
         OAuth2AccessToken accessToken = authorizedClient.getAccessToken();
 
-        String key = RedisTokenService.OAUTH2_REFRESH_TOKEN_PREFIX + loginId;
+        String key = RedisTokenService.OAUTH2_REFRESH_TOKEN_KEY_PREFIX + loginId;
         redisTokenService.saveToken(
                 key,
                 refreshToken.getTokenValue(),
@@ -42,7 +42,7 @@ public class RedisOAuth2AuthorizedClientService implements OAuth2AuthorizedClien
                 )
         );
 
-        key = RedisTokenService.OAUTH2_ACCESS_TOKEN_PREFIX + loginId;
+        key = RedisTokenService.OAUTH2_ACCESS_TOKEN_KEY_PREFIX + loginId;
         redisTokenService.saveToken(
                 key,
                 accessToken.getTokenValue(),

--- a/src/main/java/wad/seoul_nolgoat/auth/oauth2/RedisOAuth2AuthorizedClientService.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/oauth2/RedisOAuth2AuthorizedClientService.java
@@ -1,0 +1,57 @@
+package wad.seoul_nolgoat.auth.oauth2;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.stereotype.Service;
+import wad.seoul_nolgoat.auth.service.TokenService;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+@RequiredArgsConstructor
+@Service
+public class RedisOAuth2AuthorizedClientService implements OAuth2AuthorizedClientService {
+
+    private final TokenService tokenService;
+
+    @Override
+    public <T extends OAuth2AuthorizedClient> T loadAuthorizedClient(String clientRegistrationId, String principalName) {
+        return null;
+    }
+
+    @Override
+    public void saveAuthorizedClient(OAuth2AuthorizedClient authorizedClient, Authentication principal) {
+        String loginId = principal.getName();
+        OAuth2RefreshToken refreshToken = authorizedClient.getRefreshToken();
+        OAuth2AccessToken accessToken = authorizedClient.getAccessToken();
+
+        String key = TokenService.OAUTH2_REFRESH_TOKEN_PREFIX + loginId;
+        tokenService.saveToken(
+                key,
+                refreshToken.getTokenValue(),
+                Date.from(
+                        LocalDateTime.now()
+                                .plusWeeks(2)
+                                .atZone(ZoneId.systemDefault())
+                                .toInstant()
+                )
+        );
+
+        key = TokenService.OAUTH2_ACCESS_TOKEN_PREFIX + loginId;
+        tokenService.saveToken(
+                key,
+                accessToken.getTokenValue(),
+                Date.from(accessToken.getExpiresAt())
+        );
+    }
+
+    @Override
+    public void removeAuthorizedClient(String clientRegistrationId, String principalName) {
+
+    }
+}

--- a/src/main/java/wad/seoul_nolgoat/auth/oauth2/client/GoogleClient.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/oauth2/client/GoogleClient.java
@@ -1,0 +1,21 @@
+package wad.seoul_nolgoat.auth.oauth2.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "googleClient", url = "https://oauth2.googleapis.com")
+public interface GoogleClient {
+
+    @PostMapping("/token")
+    TokenResponse reissueToken(
+            @RequestParam("grant_type") String grantType, // "refresh_token"으로 고정
+            @RequestParam("client_id") String clientId,
+            @RequestParam("refresh_token") String refreshToken,
+            @RequestParam("client_secret") String clientSecret
+    );
+
+    // Refresh, Access 토큰 둘 다 사용 가능
+    @PostMapping("/revoke")
+    void unlink(@RequestParam("token") String accessToken);
+}

--- a/src/main/java/wad/seoul_nolgoat/auth/oauth2/client/KakaoApiClient.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/oauth2/client/KakaoApiClient.java
@@ -1,0 +1,12 @@
+package wad.seoul_nolgoat.auth.oauth2.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "kakaoApiClient", url = "https://kapi.kakao.com")
+public interface KakaoApiClient {
+
+    @PostMapping("/v1/user/unlink")
+    UnlinkResponse unlink(@RequestHeader("Authorization") String accessToken);
+}

--- a/src/main/java/wad/seoul_nolgoat/auth/oauth2/client/KakaoAuthClient.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/oauth2/client/KakaoAuthClient.java
@@ -9,7 +9,7 @@ public interface KakaoAuthClient {
 
     @PostMapping("/oauth/token")
     KakaoTokenResponse reissueToken(
-            @RequestParam("grant_type") String grantType,
+            @RequestParam("grant_type") String grantType, // "refresh_token"으로 고정
             @RequestParam("client_id") String clientId,
             @RequestParam("refresh_token") String refreshToken,
             @RequestParam("client_secret") String clientSecret

--- a/src/main/java/wad/seoul_nolgoat/auth/oauth2/client/KakaoAuthClient.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/oauth2/client/KakaoAuthClient.java
@@ -1,0 +1,17 @@
+package wad.seoul_nolgoat.auth.oauth2.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "kakaoAuthClient", url = "https://kauth.kakao.com")
+public interface KakaoAuthClient {
+
+    @PostMapping("/oauth/token")
+    KakaoTokenResponse reissueToken(
+            @RequestParam("grant_type") String grantType,
+            @RequestParam("client_id") String clientId,
+            @RequestParam("refresh_token") String refreshToken,
+            @RequestParam("client_secret") String clientSecret
+    );
+}

--- a/src/main/java/wad/seoul_nolgoat/auth/oauth2/client/KakaoAuthClient.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/oauth2/client/KakaoAuthClient.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 public interface KakaoAuthClient {
 
     @PostMapping("/oauth/token")
-    KakaoTokenResponse reissueToken(
+    TokenResponse reissueToken(
             @RequestParam("grant_type") String grantType, // "refresh_token"으로 고정
             @RequestParam("client_id") String clientId,
             @RequestParam("refresh_token") String refreshToken,

--- a/src/main/java/wad/seoul_nolgoat/auth/oauth2/client/KakaoTokenResponse.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/oauth2/client/KakaoTokenResponse.java
@@ -1,0 +1,13 @@
+package wad.seoul_nolgoat.auth.oauth2.client;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class KakaoTokenResponse {
+
+    private final String token_type;
+    private final String access_token;
+    private final int expires_in;
+}

--- a/src/main/java/wad/seoul_nolgoat/auth/oauth2/client/SocialClientService.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/oauth2/client/SocialClientService.java
@@ -14,6 +14,7 @@ public class SocialClientService {
 
     private final KakaoAuthClient kakaoAuthClient;
     private final KakaoApiClient kakaoApiClient;
+    private final GoogleClient googleClient;
 
     @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
     private String kakaoClientId;
@@ -21,7 +22,13 @@ public class SocialClientService {
     @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
     private String kakaoClientSecret;
 
-    public KakaoTokenResponse reissueKakaoToken(String refreshToken) {
+    @Value("${spring.security.oauth2.client.registration.google.client-id}")
+    private String googleClientId;
+
+    @Value("${spring.security.oauth2.client.registration.google.client-secret}")
+    private String googleClientSecret;
+
+    public TokenResponse reissueKakaoToken(String refreshToken) {
         return kakaoAuthClient.reissueToken(
                 GRANT_TYPE_REFRESH_TOKEN,
                 kakaoClientId,
@@ -33,5 +40,19 @@ public class SocialClientService {
     public void unlinkKakao(String accessToken) {
         UnlinkResponse response = kakaoApiClient.unlink(accessToken);
         log.info("Kakao Unlink 회원번호 : {}", response.getId());
+    }
+
+    public TokenResponse reissueGoogleToken(String refreshToken) {
+        return googleClient.reissueToken(
+                GRANT_TYPE_REFRESH_TOKEN,
+                googleClientId,
+                refreshToken,
+                googleClientSecret
+        );
+    }
+
+    public void unlinkGoogle(String accessToken) {
+        googleClient.unlink(accessToken);
+        log.info("Google Unlink");
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/auth/oauth2/client/SocialClientService.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/oauth2/client/SocialClientService.java
@@ -1,0 +1,47 @@
+package wad.seoul_nolgoat.auth.oauth2.client;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import wad.seoul_nolgoat.auth.service.TokenService;
+
+import java.util.Date;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class SocialClientService {
+
+    private static final String KAKAO_GRANT_TYPE_REFRESH_TOKEN = "refresh_token";
+
+    private final KakaoAuthClient kakaoAuthClient;
+    private final KakaoApiClient kakaoApiClient;
+    private final TokenService tokenService;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    private String clientId;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
+    private String clientSecret;
+
+    public void reissueKakaoToken(String loginId, String refreshToken) {
+        KakaoTokenResponse response = kakaoAuthClient.reissueToken(
+                KAKAO_GRANT_TYPE_REFRESH_TOKEN,
+                clientId,
+                refreshToken,
+                clientSecret
+        );
+        String key = TokenService.OAUTH2_ACCESS_TOKEN_PREFIX + loginId;
+        tokenService.saveToken(
+                key,
+                response.getAccess_token(),
+                new Date(System.currentTimeMillis() + (response.getExpires_in() * 1000L))
+        );
+    }
+
+    public void unlinkKakao(String accessToken) {
+        UnlinkResponse response = kakaoApiClient.unlink(accessToken);
+        log.info("Kakao Unlink 회원번호 : {}", response.getId());
+    }
+}

--- a/src/main/java/wad/seoul_nolgoat/auth/oauth2/client/SocialClientService.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/oauth2/client/SocialClientService.java
@@ -4,9 +4,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import wad.seoul_nolgoat.auth.service.TokenService;
-
-import java.util.Date;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -17,7 +14,6 @@ public class SocialClientService {
 
     private final KakaoAuthClient kakaoAuthClient;
     private final KakaoApiClient kakaoApiClient;
-    private final TokenService tokenService;
 
     @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
     private String clientId;
@@ -25,18 +21,12 @@ public class SocialClientService {
     @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
     private String clientSecret;
 
-    public void reissueKakaoToken(String loginId, String refreshToken) {
-        KakaoTokenResponse response = kakaoAuthClient.reissueToken(
+    public KakaoTokenResponse reissueKakaoToken(String refreshToken) {
+        return kakaoAuthClient.reissueToken(
                 KAKAO_GRANT_TYPE_REFRESH_TOKEN,
                 clientId,
                 refreshToken,
                 clientSecret
-        );
-        String key = TokenService.OAUTH2_ACCESS_TOKEN_PREFIX + loginId;
-        tokenService.saveToken(
-                key,
-                response.getAccess_token(),
-                new Date(System.currentTimeMillis() + (response.getExpires_in() * 1000L))
         );
     }
 

--- a/src/main/java/wad/seoul_nolgoat/auth/oauth2/client/SocialClientService.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/oauth2/client/SocialClientService.java
@@ -10,23 +10,23 @@ import org.springframework.stereotype.Service;
 @Service
 public class SocialClientService {
 
-    private static final String KAKAO_GRANT_TYPE_REFRESH_TOKEN = "refresh_token";
+    private static final String GRANT_TYPE_REFRESH_TOKEN = "refresh_token";
 
     private final KakaoAuthClient kakaoAuthClient;
     private final KakaoApiClient kakaoApiClient;
 
     @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
-    private String clientId;
+    private String kakaoClientId;
 
     @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
-    private String clientSecret;
+    private String kakaoClientSecret;
 
     public KakaoTokenResponse reissueKakaoToken(String refreshToken) {
         return kakaoAuthClient.reissueToken(
-                KAKAO_GRANT_TYPE_REFRESH_TOKEN,
-                clientId,
+                GRANT_TYPE_REFRESH_TOKEN,
+                kakaoClientId,
                 refreshToken,
-                clientSecret
+                kakaoClientSecret
         );
     }
 

--- a/src/main/java/wad/seoul_nolgoat/auth/oauth2/client/TokenResponse.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/oauth2/client/TokenResponse.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public class KakaoTokenResponse {
+public class TokenResponse {
 
     private final String token_type;
     private final String access_token;

--- a/src/main/java/wad/seoul_nolgoat/auth/oauth2/client/UnlinkResponse.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/oauth2/client/UnlinkResponse.java
@@ -1,0 +1,15 @@
+package wad.seoul_nolgoat.auth.oauth2.client;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import lombok.Getter;
+
+@Getter
+public class UnlinkResponse {
+
+    private final Long id;
+
+    @JsonCreator
+    public UnlinkResponse(Long id) {
+        this.id = id;
+    }
+}

--- a/src/main/java/wad/seoul_nolgoat/auth/service/AuthService.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/service/AuthService.java
@@ -17,6 +17,7 @@ import wad.seoul_nolgoat.service.user.UserService;
 import java.util.Objects;
 
 import static wad.seoul_nolgoat.auth.jwt.JwtProvider.*;
+import static wad.seoul_nolgoat.auth.oauth2.CustomOAuth2UserService.*;
 import static wad.seoul_nolgoat.auth.service.TokenService.ACCESS_TOKEN_PREFIX;
 import static wad.seoul_nolgoat.auth.service.TokenService.REFRESH_TOKEN_PREFIX;
 import static wad.seoul_nolgoat.exception.ErrorCode.*;
@@ -188,8 +189,8 @@ public class AuthService {
         String accessKey = TokenService.OAUTH2_ACCESS_TOKEN_PREFIX + loginId;
         String accessToken = tokenService.getToken(accessKey);
 
-        String registrationId = loginId.split("_")[0];
-        if (registrationId.equals("kakao")) {
+        String registrationId = loginId.split(PROVIDER_ID_DELIMITER)[0];
+        if (registrationId.equals(KAKAO)) {
             // Access 토큰이 null이면 Refresh 토큰을 이용해 재발급
             if (accessToken == null) {
                 TokenResponse tokenResponse = socialClientService.reissueKakaoToken(tokenService.getToken(refreshKey));
@@ -199,7 +200,7 @@ public class AuthService {
             }
             socialClientService.unlinkKakao(BEARER_PREFIX + accessToken);
         }
-        if (registrationId.equals("google")) {
+        if (registrationId.equals(GOOGLE)) {
             if (accessToken == null) {
                 TokenResponse tokenResponse = socialClientService.reissueGoogleToken(tokenService.getToken(refreshKey));
                 accessToken = tokenResponse.getAccess_token();

--- a/src/main/java/wad/seoul_nolgoat/auth/service/AuthService.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/service/AuthService.java
@@ -19,8 +19,8 @@ import java.util.Objects;
 
 import static wad.seoul_nolgoat.auth.jwt.JwtProvider.*;
 import static wad.seoul_nolgoat.auth.oauth2.CustomOAuth2UserService.*;
-import static wad.seoul_nolgoat.auth.service.RedisTokenService.ACCESS_TOKEN_PREFIX;
-import static wad.seoul_nolgoat.auth.service.RedisTokenService.REFRESH_TOKEN_PREFIX;
+import static wad.seoul_nolgoat.auth.service.RedisTokenService.ACCESS_TOKEN_KEY_PREFIX;
+import static wad.seoul_nolgoat.auth.service.RedisTokenService.REFRESH_TOKEN_KEY_PREFIX;
 import static wad.seoul_nolgoat.exception.ErrorCode.*;
 
 @RequiredArgsConstructor
@@ -50,7 +50,7 @@ public class AuthService {
                 REFRESH_TOKEN_EXPIRATION_TIME
         );
 
-        String key = REFRESH_TOKEN_PREFIX + loginId;
+        String key = REFRESH_TOKEN_KEY_PREFIX + loginId;
         redisTokenService.saveToken(
                 key,
                 refreshToken,
@@ -90,7 +90,7 @@ public class AuthService {
     // Refresh 토큰 검증
     public void verifyRefreshToken(String refreshToken, HttpServletResponse response) {
         try {
-            String key = REFRESH_TOKEN_PREFIX + getLoginId(refreshToken);
+            String key = REFRESH_TOKEN_KEY_PREFIX + getLoginId(refreshToken);
 
             // 캐시에 해당 Refresh 토큰이 존재하는지 확인
             if (Objects.equals(redisTokenService.getToken(key), refreshToken)) {
@@ -129,7 +129,7 @@ public class AuthService {
 
     // Access 토큰 검증
     public void verifyAccessToken(String accessToken) {
-        String key = ACCESS_TOKEN_PREFIX + getLoginId(accessToken);
+        String key = ACCESS_TOKEN_KEY_PREFIX + getLoginId(accessToken);
 
         // Access 토큰 블랙리스트 여부 확인
         if (Objects.equals(redisTokenService.getToken(key), accessToken)) {
@@ -149,12 +149,12 @@ public class AuthService {
 
     // 캐시에서 Refresh 토큰 삭제
     public void deleteRefreshToken(String loginId) {
-        redisTokenService.deleteToken(REFRESH_TOKEN_PREFIX + loginId);
+        redisTokenService.deleteToken(REFRESH_TOKEN_KEY_PREFIX + loginId);
     }
 
     // 캐시에 Access 토큰 블랙리스트 처리
     public void saveAccessTokenToBlacklist(String accessToken) {
-        String key = ACCESS_TOKEN_PREFIX + getLoginId(accessToken);
+        String key = ACCESS_TOKEN_KEY_PREFIX + getLoginId(accessToken);
         redisTokenService.saveToken(
                 key,
                 accessToken,
@@ -186,8 +186,8 @@ public class AuthService {
 
     @Transactional
     public void deleteUserByLoginId(String loginId) {
-        String refreshKey = RedisTokenService.OAUTH2_REFRESH_TOKEN_PREFIX + loginId;
-        String accessKey = RedisTokenService.OAUTH2_ACCESS_TOKEN_PREFIX + loginId;
+        String refreshKey = RedisTokenService.OAUTH2_REFRESH_TOKEN_KEY_PREFIX + loginId;
+        String accessKey = RedisTokenService.OAUTH2_ACCESS_TOKEN_KEY_PREFIX + loginId;
         String accessToken = redisTokenService.getToken(accessKey);
 
         String registrationId = loginId.split(PROVIDER_ID_DELIMITER)[0];

--- a/src/main/java/wad/seoul_nolgoat/auth/service/AuthService.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/service/AuthService.java
@@ -11,8 +11,9 @@ import org.springframework.transaction.annotation.Transactional;
 import wad.seoul_nolgoat.auth.jwt.JwtProvider;
 import wad.seoul_nolgoat.auth.oauth2.client.SocialClientService;
 import wad.seoul_nolgoat.auth.oauth2.client.TokenResponse;
+import wad.seoul_nolgoat.domain.user.User;
+import wad.seoul_nolgoat.domain.user.UserRepository;
 import wad.seoul_nolgoat.exception.ApiException;
-import wad.seoul_nolgoat.service.user.UserService;
 
 import java.util.Objects;
 
@@ -36,7 +37,7 @@ public class AuthService {
     private final JwtProvider jwtProvider;
     private final TokenService tokenService;
     private final SocialClientService socialClientService;
-    private final UserService userService;
+    private final UserRepository userRepository;
 
     @Value("${spring.csrf.protection.uuid}")
     private String csrfProtectionUuid;
@@ -212,6 +213,8 @@ public class AuthService {
         tokenService.deleteToken(refreshKey);
 
         // 유저의 isDeleted를 true로 변경
-        userService.deleteByLoginId(loginId);
+        User user = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new ApiException(USER_NOT_FOUND));
+        user.delete();
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/auth/service/AuthService.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/service/AuthService.java
@@ -184,13 +184,13 @@ public class AuthService {
 
     @Transactional
     public void deleteUserByLoginId(String loginId) {
-        String key = TokenService.OAUTH2_ACCESS_TOKEN_PREFIX + loginId;
-        String accessToken = tokenService.getToken(key);
+        String accessKey = TokenService.OAUTH2_ACCESS_TOKEN_PREFIX + loginId;
+        String accessToken = tokenService.getToken(accessKey);
 
         // Access 토큰이 null이면 Refresh 토큰을 이용해 재발급
+        String refreshKey = TokenService.OAUTH2_REFRESH_TOKEN_PREFIX + loginId;
         if (accessToken == null) {
-            key = TokenService.OAUTH2_REFRESH_TOKEN_PREFIX + loginId;
-            KakaoTokenResponse kakaoTokenResponse = socialClientService.reissueKakaoToken(tokenService.getToken(key));
+            KakaoTokenResponse kakaoTokenResponse = socialClientService.reissueKakaoToken(tokenService.getToken(refreshKey));
 
             // 회원 탈퇴를 위한 재발급이기 때문에, Redis에 저장하지 않음
             accessToken = kakaoTokenResponse.getAccess_token();
@@ -198,7 +198,7 @@ public class AuthService {
         socialClientService.unlinkKakao(BEARER_PREFIX + accessToken);
 
         // Refresh 토큰은 남아있기 때문에 삭제
-        tokenService.deleteToken(key);
+        tokenService.deleteToken(refreshKey);
 
         // 유저의 isDeleted를 true로 변경
         userService.deleteByLoginId(loginId);

--- a/src/main/java/wad/seoul_nolgoat/auth/service/RedisTokenService.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/service/RedisTokenService.java
@@ -11,10 +11,10 @@ import java.util.concurrent.TimeUnit;
 @Service
 public class RedisTokenService {
 
-    public static final String REFRESH_TOKEN_PREFIX = "RT:";
-    public static final String ACCESS_TOKEN_PREFIX = "AT:";
-    public static final String OAUTH2_REFRESH_TOKEN_PREFIX = "RT(oauth2):";
-    public static final String OAUTH2_ACCESS_TOKEN_PREFIX = "AT(oauth2):";
+    public static final String REFRESH_TOKEN_KEY_PREFIX = "RT:";
+    public static final String ACCESS_TOKEN_KEY_PREFIX = "AT:";
+    public static final String OAUTH2_REFRESH_TOKEN_KEY_PREFIX = "RT(oauth2):";
+    public static final String OAUTH2_ACCESS_TOKEN_KEY_PREFIX = "AT(oauth2):";
 
     private final RedisTemplate<String, String> redisTemplate;
 

--- a/src/main/java/wad/seoul_nolgoat/auth/service/RedisTokenService.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/service/RedisTokenService.java
@@ -9,7 +9,7 @@ import java.util.concurrent.TimeUnit;
 
 @RequiredArgsConstructor
 @Service
-public class TokenService {
+public class RedisTokenService {
 
     public static final String REFRESH_TOKEN_PREFIX = "RT:";
     public static final String ACCESS_TOKEN_PREFIX = "AT:";

--- a/src/main/java/wad/seoul_nolgoat/auth/service/TokenService.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/service/TokenService.java
@@ -13,6 +13,8 @@ public class TokenService {
 
     public static final String REFRESH_TOKEN_PREFIX = "RT:";
     public static final String ACCESS_TOKEN_PREFIX = "AT:";
+    public static final String OAUTH2_REFRESH_TOKEN_PREFIX = "RT(oauth2):";
+    public static final String OAUTH2_ACCESS_TOKEN_PREFIX = "AT(oauth2):";
 
     private final RedisTemplate<String, String> redisTemplate;
 

--- a/src/main/java/wad/seoul_nolgoat/config/SecurityConfig.java
+++ b/src/main/java/wad/seoul_nolgoat/config/SecurityConfig.java
@@ -20,6 +20,7 @@ import wad.seoul_nolgoat.auth.jwt.JwtAuthenticationEntryPoint;
 import wad.seoul_nolgoat.auth.jwt.JwtFilter;
 import wad.seoul_nolgoat.auth.oauth2.CustomOAuth2UserService;
 import wad.seoul_nolgoat.auth.oauth2.CustomSuccessHandler;
+import wad.seoul_nolgoat.auth.oauth2.OAuth2AuthorizationRequestResolverImpl;
 import wad.seoul_nolgoat.auth.oauth2.RedisOAuth2AuthorizedClientService;
 import wad.seoul_nolgoat.auth.service.AuthService;
 
@@ -35,6 +36,7 @@ public class SecurityConfig {
     private final AuthService authService;
     private final ObjectMapper objectMapper;
     private final RedisOAuth2AuthorizedClientService oAuth2AuthorizedClientService;
+    private final OAuth2AuthorizationRequestResolverImpl oAuth2AuthorizationRequestResolver;
 
     @Value("${app.urls.frontend-base-url}")
     private String frontendBaseUrl;
@@ -51,6 +53,9 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .oauth2Login(oauth2 -> oauth2
+                        .authorizationEndpoint(endpoint -> endpoint
+                                .authorizationRequestResolver(oAuth2AuthorizationRequestResolver)
+                        )
                         .userInfoEndpoint(userInfo -> userInfo
                                 .userService(customOAuth2UserService)
                         )

--- a/src/main/java/wad/seoul_nolgoat/config/SecurityConfig.java
+++ b/src/main/java/wad/seoul_nolgoat/config/SecurityConfig.java
@@ -20,6 +20,7 @@ import wad.seoul_nolgoat.auth.jwt.JwtAuthenticationEntryPoint;
 import wad.seoul_nolgoat.auth.jwt.JwtFilter;
 import wad.seoul_nolgoat.auth.oauth2.CustomOAuth2UserService;
 import wad.seoul_nolgoat.auth.oauth2.CustomSuccessHandler;
+import wad.seoul_nolgoat.auth.oauth2.RedisOAuth2AuthorizedClientService;
 import wad.seoul_nolgoat.auth.service.AuthService;
 
 import java.util.List;
@@ -33,6 +34,7 @@ public class SecurityConfig {
     private final CustomSuccessHandler customSuccessHandler;
     private final AuthService authService;
     private final ObjectMapper objectMapper;
+    private final RedisOAuth2AuthorizedClientService oAuth2AuthorizedClientService;
 
     @Value("${app.urls.frontend-base-url}")
     private String frontendBaseUrl;
@@ -52,6 +54,7 @@ public class SecurityConfig {
                         .userInfoEndpoint(userInfo -> userInfo
                                 .userService(customOAuth2UserService)
                         )
+                        .authorizedClientService(oAuth2AuthorizedClientService)
                         .successHandler(customSuccessHandler)
                 )
                 .exceptionHandling(exceptions -> exceptions

--- a/src/main/java/wad/seoul_nolgoat/config/SecurityConfig.java
+++ b/src/main/java/wad/seoul_nolgoat/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -24,6 +25,7 @@ import wad.seoul_nolgoat.auth.service.AuthService;
 import java.util.List;
 
 @RequiredArgsConstructor
+@EnableWebSecurity
 @Configuration
 public class SecurityConfig {
 

--- a/src/main/java/wad/seoul_nolgoat/domain/user/User.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/user/User.java
@@ -57,4 +57,8 @@ public class User extends BaseTimeEntity {
     public void delete() {
         this.isDeleted = true;
     }
+
+    public void reactivate() {
+        this.isDeleted = false;
+    }
 }

--- a/src/main/java/wad/seoul_nolgoat/service/user/UserService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/user/UserService.java
@@ -1,8 +1,12 @@
 package wad.seoul_nolgoat.service.user;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import wad.seoul_nolgoat.auth.oauth2.dto.OAuth2Response;
+import wad.seoul_nolgoat.auth.oauth2.dto.OAuth2UserDto;
+import wad.seoul_nolgoat.auth.oauth2.dto.OAuth2UserImpl;
 import wad.seoul_nolgoat.auth.web.dto.response.UserProfileDto;
 import wad.seoul_nolgoat.domain.user.User;
 import wad.seoul_nolgoat.domain.user.UserRepository;
@@ -12,6 +16,7 @@ import wad.seoul_nolgoat.web.user.dto.request.UserSaveDto;
 import wad.seoul_nolgoat.web.user.dto.request.UserUpdateDto;
 import wad.seoul_nolgoat.web.user.dto.response.UserDetailsDto;
 
+import static wad.seoul_nolgoat.auth.oauth2.CustomOAuth2UserService.PROVIDER_ID_DELIMITER;
 import static wad.seoul_nolgoat.exception.ErrorCode.USER_NOT_FOUND;
 
 @RequiredArgsConstructor
@@ -31,11 +36,55 @@ public class UserService {
         return UserMapper.toUserDetailsDto(user);
     }
 
+    public User findByLoginId(String loginId) {
+        User user = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new ApiException(USER_NOT_FOUND));
+
+        return user;
+    }
+
     public UserProfileDto getLoginUserDetails(String loginId) {
         User user = userRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new ApiException(USER_NOT_FOUND));
 
         return UserMapper.toUserProfileDto(user);
+    }
+
+    @Transactional
+    public OAuth2User processOAuth2User(OAuth2Response oAuth2Response) {
+        String uniqueProviderId = oAuth2Response.getProvider() + PROVIDER_ID_DELIMITER + oAuth2Response.getProviderId();
+        String nickname = oAuth2Response.getNickname();
+        String profileImage = oAuth2Response.getProfileImage();
+
+        if (!userRepository.existsByLoginId(uniqueProviderId)) {
+            userRepository.save(
+                    new User(
+                            uniqueProviderId,
+                            null,
+                            nickname,
+                            profileImage,
+                            null,
+                            null
+                    )
+            );
+            OAuth2UserDto oAuth2UserDto = new OAuth2UserDto(uniqueProviderId);
+            return new OAuth2UserImpl(oAuth2UserDto);
+        }
+
+        User user = userRepository.findByLoginId(uniqueProviderId)
+                .orElseThrow(() -> new ApiException(USER_NOT_FOUND));
+        if (user.isDeleted()) {
+            user.reactivate();
+        }
+        user.update(
+                null,
+                nickname,
+                profileImage
+        );
+
+        OAuth2UserDto oAuth2UserDto = new OAuth2UserDto(uniqueProviderId);
+
+        return new OAuth2UserImpl(oAuth2UserDto);
     }
 
     @Transactional
@@ -47,12 +96,5 @@ public class UserService {
                 userUpdateDto.getNickname(),
                 userUpdateDto.getProfileImage()
         );
-    }
-
-    @Transactional
-    public void deleteByLoginId(String loginId) {
-        User user = userRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new ApiException(USER_NOT_FOUND));
-        user.delete();
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/service/user/UserService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/user/UserService.java
@@ -50,8 +50,8 @@ public class UserService {
     }
 
     @Transactional
-    public void deleteById(Long userId) {
-        User user = userRepository.findById(userId)
+    public void deleteByLoginId(String loginId) {
+        User user = userRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new ApiException(USER_NOT_FOUND));
         user.delete();
     }

--- a/src/main/java/wad/seoul_nolgoat/web/admin/AdminController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/admin/AdminController.java
@@ -34,7 +34,7 @@ public class AdminController {
     public ResponseEntity<TestTokenDto> getTestToken() {
         String accessToken = authService.createTestToken(TEST_ID, "access", 3 * 60 * 1000L);
         String refreshToken = authService.createTestToken(TEST_ID, "refresh", 3 * 60 * 1000L);
-        redisTokenService.saveToken(RedisTokenService.REFRESH_TOKEN_PREFIX + TEST_ID, refreshToken, new Date(System.currentTimeMillis() + 3 * 60 * 1000L));
+        redisTokenService.saveToken(RedisTokenService.REFRESH_TOKEN_KEY_PREFIX + TEST_ID, refreshToken, new Date(System.currentTimeMillis() + 3 * 60 * 1000L));
 
         return ResponseEntity
                 .ok(new TestTokenDto(accessToken, refreshToken));

--- a/src/main/java/wad/seoul_nolgoat/web/admin/AdminController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/admin/AdminController.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import wad.seoul_nolgoat.auth.service.AuthService;
-import wad.seoul_nolgoat.auth.service.TokenService;
+import wad.seoul_nolgoat.auth.service.RedisTokenService;
 import wad.seoul_nolgoat.web.admin.dto.response.TestTokenDto;
 
 import java.util.Date;
@@ -19,7 +19,7 @@ public class AdminController {
     private static final String TEST_ID = "kakao_3656161397";
 
     private final AuthService authService;
-    private final TokenService tokenService;
+    private final RedisTokenService redisTokenService;
 
     @PostMapping("/expired-token")
     public ResponseEntity<TestTokenDto> getExpiredToken() {
@@ -34,7 +34,7 @@ public class AdminController {
     public ResponseEntity<TestTokenDto> getTestToken() {
         String accessToken = authService.createTestToken(TEST_ID, "access", 3 * 60 * 1000L);
         String refreshToken = authService.createTestToken(TEST_ID, "refresh", 3 * 60 * 1000L);
-        tokenService.saveToken(TokenService.REFRESH_TOKEN_PREFIX + TEST_ID, refreshToken, new Date(System.currentTimeMillis() + 3 * 60 * 1000L));
+        redisTokenService.saveToken(RedisTokenService.REFRESH_TOKEN_PREFIX + TEST_ID, refreshToken, new Date(System.currentTimeMillis() + 3 * 60 * 1000L));
 
         return ResponseEntity
                 .ok(new TestTokenDto(accessToken, refreshToken));

--- a/src/main/java/wad/seoul_nolgoat/web/user/UserController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/user/UserController.java
@@ -51,13 +51,4 @@ public class UserController {
                 .noContent()
                 .build();
     }
-
-    @DeleteMapping("/{userId}")
-    public ResponseEntity<Void> deleteById(@PathVariable Long userId) {
-        userService.deleteById(userId);
-
-        return ResponseEntity
-                .noContent()
-                .build();
-    }
 }


### PR DESCRIPTION
## ✔️ 작업 내용

- **OpenFeign을 활용한 Social Client 인터페이스 구현** 
  - KakaoAuthClient
    - 토큰 재발급
  - KakaoApiClient
    - 계정 연결 해제
  - GoogleClient
    - 토큰 재발급
    - 계정 연결 해제

- **OAuth2 관련 인터페이스 커스텀 구현**
  - OAuth2AuthorizationRequestResolverImpl
    - `Google` 로그인의 경우에는 `Refresh` 토큰을 발급받기 위해 특정 파라미터(`prompt`, `access_type`)를 추가해야 합니다.
    - 이처럼, 분기 설정을 위해 `OAuth2AuthorizationRequestResolver`를 커스텀 구현했습니다.
  - RedisOAuth2AuthorizedClientService
    - 기본적으로 `OAuth2AuthorizedClient`는 `인메모리` 방식으로 관리됩니다.
    - 저희는 토큰 관리만 필요하기 때문에, `Redis`를 활용해 OAuth2 토큰을 관리하도록 `OAuth2AuthorizedClientService`를 커스텀 구현했습니다.

- **회원 탈퇴 로직**
  1. 캐시에 OAuth2 `Access` 토큰이 존재하는지 확인합니다.
  2. 만약 기한이 만료되어 `Access` 토큰이 존재하지 않는다면, OAuth2 `Refresh` 토큰을 사용하여 `Access` 토큰을 재발급받습니다.
  3. OAuth2 `Access` 토큰으로 계정 연결 해제를 신청합니다. 
  4. 연결 해제에 성공하면, 캐시에서 OAuth2 `Refresh` 토큰을 삭제하고, 해당 유저의 `isDeleted` 필드를 `true`로 변경합니다.
 
- **재가입 처리 로직**
  1. 동일 애플리케이션 내에서는 `Provider ID`가 고정값입니다. (유저 고유 ID)
  2. 따라서 `Login ID(ex - kakao_${providerId})`로 존재 여부를 확인합니다.
  3. 만약 유저가 존재한다면, 해당 유저의 `isDeleted` 필드를 `false`로 변경합니다.

## 📋 요약

- 소셜 로그인 제공자와의 계정 연결 해제를 포함한 OAuth2 회원 탈퇴 로직 구현
- `Redis`를 활용한 OAuth2 토큰 관리
- 탈퇴한 유저가 재가입 시 기존 데이터 복구

## 🔒 관련 이슈

close #36 

## ➕ 기타 사항

- **카카오 동의 항목 설정 문제**
  - `Kakao` 로그인 시, 선택 항목을 첫 로그인에서 선택하지 않으면, 이후에 진행하는 로그인에서는 필수 항목으로 변경되어 강제로 선택해야 하는 문제가 발생했습니다.
  - 이는 `.yml` 파일의 `scope` 설정이 잘못되어 발생한 문제였습니다.
  - 해당 설정은 추가 항목 동의를 받을 때 사용하는 것인데, 초기 동의 항목으로 착각하여 잘못 사용했습니다.
      ```yaml
      scope:
        - profile_nickname
        - profile_image
      ```
  - `.yml` 파일에서 해당 설정을 지워 문제를 해결했습니다.

- **회원 탈퇴 시, 연관 데이터 처리 고민**
  -  탈퇴 유저와 연관된 데이터(`북마크`, `리뷰`)를 어떤 방식으로 처리할지 고민 중입니다.
  - 적절한 방식을 찾아 추후에 적용할 예정입니다.