### PR TITLE
AuthUrlManager 수정

### DIFF
--- a/src/main/java/wad/seoul_nolgoat/auth/AuthUrlManager.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/AuthUrlManager.java
@@ -21,13 +21,12 @@ public class AuthUrlManager {
 
                 new AntPathRequestMatcher("/api/parties/**"),
 
-                new AntPathRequestMatcher("/api/inquiries/{userId}", "POST"),
+                new AntPathRequestMatcher("/api/inquiries", "POST"),
                 new AntPathRequestMatcher("/api/inquiries/{inquiryId}", "PUT"),
                 new AntPathRequestMatcher("/api/inquiries/{inquiryId}", "DELETE"),
 
-                new AntPathRequestMatcher("/api/notices/{userId}", "POST"),
+                new AntPathRequestMatcher("/api/notices", "POST"),
                 new AntPathRequestMatcher("/api/notices/{noticeId}", "PUT"),
-                new AntPathRequestMatcher("/api/notices/{noticeId}/views", "PUT"),
                 new AntPathRequestMatcher("/api/notices/{noticeId}", "DELETE")
         };
     }


### PR DESCRIPTION
## ✔️ 작업 내용

- **Notice, Inquiry 관련 URL을 올바르게 수정**
  - `new AntPathRequestMatcher("/api/inquiries/{userId}", "POST")`
  => `new AntPathRequestMatcher("/api/inquiries", "POST")`
  - `new AntPathRequestMatcher("/api/notices/{userId}", "POST")`
  => `new AntPathRequestMatcher("/api/notices", "POST")`
- **불필요한 URL 삭제**
  - `new AntPathRequestMatcher("/api/notices/{noticeId}/views", "PUT")` 삭제

## 📋 요약

- 인증이 필요한 `URL` 모음을 올바르게 수정

## 🔒 관련 이슈

close #53

## ➕ 기타 사항