### PR TITLE
누락된 트랜잭션 적용 및 컨트롤러 응답 타입 통일

### DIFF
--- a/src/main/java/wad/seoul_nolgoat/auth/oauth2/security/CustomOAuth2UserService.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/oauth2/security/CustomOAuth2UserService.java
@@ -10,8 +10,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import wad.seoul_nolgoat.auth.oauth2.dto.GoogleResponse;
 import wad.seoul_nolgoat.auth.oauth2.dto.KakaoResponse;
+import wad.seoul_nolgoat.auth.service.AuthService;
 import wad.seoul_nolgoat.exception.ApiException;
-import wad.seoul_nolgoat.service.user.UserService;
 
 import static wad.seoul_nolgoat.exception.ErrorCode.UNSUPPORTED_PROVIDER;
 
@@ -24,7 +24,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     public static final String GOOGLE = "google";
     public static final String PROVIDER_ID_DELIMITER = "_";
 
-    private final UserService userService;
+    private final AuthService authService;
 
     @Transactional
     @Override
@@ -33,10 +33,10 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
         if (registrationId.equals(KAKAO)) {
-            return userService.processOAuth2User(new KakaoResponse(oAuth2User.getAttributes()));
+            return authService.processOAuth2User(new KakaoResponse(oAuth2User.getAttributes()));
         }
         if (registrationId.equals(GOOGLE)) {
-            return userService.processOAuth2User(new GoogleResponse(oAuth2User.getAttributes()));
+            return authService.processOAuth2User(new GoogleResponse(oAuth2User.getAttributes()));
         }
         log.error("Unsupported OAuth2 provider: {}", registrationId);
         throw new ApiException(UNSUPPORTED_PROVIDER);

--- a/src/main/java/wad/seoul_nolgoat/auth/security/AuthenticationEntryPointImpl.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/security/AuthenticationEntryPointImpl.java
@@ -12,7 +12,7 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 import wad.seoul_nolgoat.exception.ApiException;
-import wad.seoul_nolgoat.web.exception.dto.response.ErrorResponse;
+import wad.seoul_nolgoat.exception.dto.response.ErrorResponse;
 
 import java.io.IOException;
 

--- a/src/main/java/wad/seoul_nolgoat/auth/web/AuthController.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/web/AuthController.java
@@ -91,7 +91,7 @@ public class AuthController {
         authService.saveAccessTokenToBlacklist(authorizationHeader.split(" ")[1]);
 
         // 소셜 계정 연동 unlink 및 유저 상태 변경
-        authService.deleteUserByLoginId(loginUser.getName());
+        authService.unlinkSocialAccount(loginUser.getName());
 
         return ResponseEntity
                 .noContent()

--- a/src/main/java/wad/seoul_nolgoat/domain/bookmark/BookmarkRepository.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/bookmark/BookmarkRepository.java
@@ -4,7 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -15,7 +14,6 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     boolean existsByUserIdAndStoreId(Long userId, Long storeId);
 
     @Modifying
-    @Transactional
     @Query("DELETE FROM Bookmark b WHERE b.user.id = :userId AND b.store.id = :storeId")
     void deleteByUserIdAndStoreId(@Param("userId") Long userId, @Param("storeId") Long storeId);
 }

--- a/src/main/java/wad/seoul_nolgoat/domain/store/StoreRepository.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/store/StoreRepository.java
@@ -1,6 +1,5 @@
 package wad.seoul_nolgoat.domain.store;
 
-import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -8,7 +7,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface StoreRepository extends JpaRepository<Store, Long>, StoreRepositoryCustom {
 
-    @Transactional
     @Modifying
     @Query("UPDATE Store s SET s.nolgoatAverageGrade = :nolgoatAverageGrade WHERE s.id = :storeId")
     void updateNolgoatAverageGrade(@Param("storeId") Long storeId, @Param("nolgoatAverageGrade") double nolgoatAverageGrade);

--- a/src/main/java/wad/seoul_nolgoat/exception/GlobalExceptionHandler.java
+++ b/src/main/java/wad/seoul_nolgoat/exception/GlobalExceptionHandler.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import wad.seoul_nolgoat.web.exception.dto.response.ErrorResponse;
+import wad.seoul_nolgoat.exception.dto.response.ErrorResponse;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/wad/seoul_nolgoat/exception/dto/response/ErrorResponse.java
+++ b/src/main/java/wad/seoul_nolgoat/exception/dto/response/ErrorResponse.java
@@ -1,4 +1,4 @@
-package wad.seoul_nolgoat.web.exception.dto.response;
+package wad.seoul_nolgoat.exception.dto.response;
 
 import lombok.Getter;
 import wad.seoul_nolgoat.exception.ErrorCode;

--- a/src/main/java/wad/seoul_nolgoat/service/bookmark/BookmarkService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/bookmark/BookmarkService.java
@@ -2,6 +2,7 @@ package wad.seoul_nolgoat.service.bookmark;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import wad.seoul_nolgoat.domain.bookmark.Bookmark;
 import wad.seoul_nolgoat.domain.bookmark.BookmarkRepository;
 import wad.seoul_nolgoat.domain.store.Store;
@@ -18,6 +19,7 @@ import static wad.seoul_nolgoat.exception.ErrorCode.STORE_NOT_FOUND;
 import static wad.seoul_nolgoat.exception.ErrorCode.USER_NOT_FOUND;
 
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 @Service
 public class BookmarkService {
 
@@ -25,6 +27,7 @@ public class BookmarkService {
     private final UserRepository userRepository;
     private final StoreRepository storeRepository;
 
+    @Transactional
     public Long save(String loginId, Long storeId) {
         User user = userRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new ApiException(USER_NOT_FOUND));
@@ -39,6 +42,7 @@ public class BookmarkService {
         ).getId();
     }
 
+    @Transactional
     public void deleteById(Long userId, Long storeId) {
         if (!bookmarkRepository.existsByUserIdAndStoreId(userId, storeId)) {
             throw new RuntimeException("존재하지 않는 북마크입니다.");

--- a/src/main/java/wad/seoul_nolgoat/service/databaseSeeder/DatabaseSeederService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/databaseSeeder/DatabaseSeederService.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import wad.seoul_nolgoat.domain.store.Store;
 import wad.seoul_nolgoat.domain.store.StoreRepository;
 import wad.seoul_nolgoat.domain.store.StoreType;
@@ -34,6 +35,7 @@ public class DatabaseSeederService {
 
     private final RateLimiter rateLimiter = RateLimiter.create(RATE_LIMIT); // 초당 50회 호출 제한
 
+    @Transactional
     public void seedInitialStoreData(StoreType storeType) {
         int startIdx = INITIAL_START_IDX;
         int endIdx = INITIAL_END_IDX;

--- a/src/main/java/wad/seoul_nolgoat/service/inquiry/InquiryService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/inquiry/InquiryService.java
@@ -21,12 +21,14 @@ import static wad.seoul_nolgoat.exception.ErrorCode.INQUIRY_NOT_FOUND;
 import static wad.seoul_nolgoat.exception.ErrorCode.USER_NOT_FOUND;
 
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 @Service
 public class InquiryService {
 
     private final InquiryRepository inquiryRepository;
     private final UserRepository userRepository;
 
+    @Transactional
     public Long save(String loginId, InquirySaveDto inquirySaveDto) {
         User user = userRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new ApiException(USER_NOT_FOUND));
@@ -61,6 +63,7 @@ public class InquiryService {
         );
     }
 
+    @Transactional
     public void deleteById(Long inquiryId) {
         if (!inquiryRepository.existsById(inquiryId)) {
             throw new ApiException(INQUIRY_NOT_FOUND);

--- a/src/main/java/wad/seoul_nolgoat/service/notice/NoticeService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/notice/NoticeService.java
@@ -21,12 +21,14 @@ import static wad.seoul_nolgoat.exception.ErrorCode.NOTICE_NOT_FOUND;
 import static wad.seoul_nolgoat.exception.ErrorCode.USER_NOT_FOUND;
 
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 @Service
 public class NoticeService {
 
     private final NoticeRepository noticeRepository;
     private final UserRepository userRepository;
 
+    @Transactional
     public Long save(String loginId, NoticeSaveDto noticeSaveDto) {
         User user = userRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new ApiException(USER_NOT_FOUND));
@@ -60,6 +62,7 @@ public class NoticeService {
         );
     }
 
+    @Transactional
     public void deleteById(Long noticeId) {
         if (!noticeRepository.existsById(noticeId)) {
             throw new ApiException(NOTICE_NOT_FOUND);

--- a/src/main/java/wad/seoul_nolgoat/service/review/ReviewService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/review/ReviewService.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import static wad.seoul_nolgoat.exception.ErrorCode.*;
 
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 @Service
 public class ReviewService {
 
@@ -33,6 +34,7 @@ public class ReviewService {
     private final StoreService storeService;
     private final S3Service s3Service;
 
+    @Transactional
     public Long save(
             String loginId,
             Long storeId,
@@ -84,6 +86,7 @@ public class ReviewService {
         );
     }
 
+    @Transactional
     public void deleteById(Long reviewId) {
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new ApiException(REVIEW_NOT_FOUND));

--- a/src/main/java/wad/seoul_nolgoat/service/search/filter/FilterService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/search/filter/FilterService.java
@@ -2,6 +2,7 @@ package wad.seoul_nolgoat.service.search.filter;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import wad.seoul_nolgoat.domain.store.StoreRepository;
 import wad.seoul_nolgoat.domain.store.StoreType;
 import wad.seoul_nolgoat.service.search.dto.StoreForDistanceSortDto;
@@ -13,6 +14,7 @@ import java.util.List;
 import java.util.Set;
 
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 @Service
 public class FilterService {
 

--- a/src/main/java/wad/seoul_nolgoat/service/store/StoreService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/store/StoreService.java
@@ -13,6 +13,7 @@ import wad.seoul_nolgoat.web.store.dto.response.StoreDetailsDto;
 import static wad.seoul_nolgoat.exception.ErrorCode.STORE_NOT_FOUND;
 
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 @Service
 public class StoreService {
 

--- a/src/main/java/wad/seoul_nolgoat/service/user/UserService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/user/UserService.java
@@ -68,7 +68,10 @@ public class UserService {
         String nickname = oAuth2Response.getNickname();
         String profileImage = oAuth2Response.getProfileImage();
 
-        if (!userRepository.existsByLoginId(uniqueProviderId)) {
+        User user = userRepository.findByLoginId(uniqueProviderId)
+                .orElse(null);
+
+        if (user == null) {
             userRepository.save(
                     new User(
                             uniqueProviderId,
@@ -82,9 +85,6 @@ public class UserService {
             OAuth2UserDto oAuth2UserDto = new OAuth2UserDto(uniqueProviderId);
             return new OAuth2UserImpl(oAuth2UserDto);
         }
-
-        User user = userRepository.findByLoginId(uniqueProviderId)
-                .orElseThrow(() -> new ApiException(USER_NOT_FOUND));
 
         // 탈퇴 유저라면 계정을 다시 활성화
         if (user.isDeleted()) {

--- a/src/main/java/wad/seoul_nolgoat/service/user/UserService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/user/UserService.java
@@ -20,11 +20,13 @@ import static wad.seoul_nolgoat.auth.oauth2.security.CustomOAuth2UserService.PRO
 import static wad.seoul_nolgoat.exception.ErrorCode.USER_NOT_FOUND;
 
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 @Service
 public class UserService {
 
     private final UserRepository userRepository;
 
+    @Transactional
     public Long save(UserSaveDto userSaveDto) {
         return userRepository.save(UserMapper.toEntity(userSaveDto)).getId();
     }

--- a/src/main/java/wad/seoul_nolgoat/service/user/UserService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/user/UserService.java
@@ -37,13 +37,6 @@ public class UserService {
         return UserMapper.toUserDetailsDto(user);
     }
 
-    public User findByLoginId(String loginId) {
-        User user = userRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new ApiException(USER_NOT_FOUND));
-
-        return user;
-    }
-
     public UserProfileDto getLoginUserDetails(String loginId) {
         User user = userRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new ApiException(USER_NOT_FOUND));

--- a/src/main/java/wad/seoul_nolgoat/web/inquiry/InquiryController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/inquiry/InquiryController.java
@@ -51,7 +51,7 @@ public class InquiryController {
     }
 
     @PutMapping("/{inquiryId}")
-    public ResponseEntity<?> update(
+    public ResponseEntity<Void> update(
             @PathVariable Long inquiryId,
             @RequestBody InquiryUpdateDto inquiryUpdateDto
     ) {

--- a/src/main/java/wad/seoul_nolgoat/web/notice/NoticeController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/notice/NoticeController.java
@@ -51,7 +51,7 @@ public class NoticeController {
     }
 
     @PutMapping("/{noticeId}")
-    public ResponseEntity<?> update(
+    public ResponseEntity<Void> update(
             @PathVariable Long noticeId,
             @RequestBody NoticeUpdateDto noticeUpdateDto
     ) {

--- a/src/main/java/wad/seoul_nolgoat/web/review/ReviewController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/review/ReviewController.java
@@ -24,7 +24,7 @@ public class ReviewController {
     private final ReviewService reviewService;
 
     @PostMapping("/{storeId}")
-    public ResponseEntity<?> createReview(
+    public ResponseEntity<Void> createReview(
             @AuthenticationPrincipal OAuth2User loginUser,
             @PathVariable Long storeId,
             @RequestPart(value = "file", required = false) MultipartFile image,
@@ -54,7 +54,7 @@ public class ReviewController {
 
     // 현재 사용하지 않음
     @PutMapping("/{reviewId}")
-    public ResponseEntity<?> update(
+    public ResponseEntity<Void> update(
             @PathVariable Long reviewId,
             @Valid @RequestBody ReviewUpdateDto reviewUpdateDto
     ) {

--- a/src/main/java/wad/seoul_nolgoat/web/user/UserController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/user/UserController.java
@@ -20,7 +20,7 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping
-    public ResponseEntity<?> createUser(
+    public ResponseEntity<Void> createUser(
             @Valid @RequestBody UserSaveDto userSaveDto,
             UriComponentsBuilder uriComponentsBuilder
     ) {
@@ -41,7 +41,7 @@ public class UserController {
     }
 
     @PutMapping("/{userId}")
-    public ResponseEntity<?> update(
+    public ResponseEntity<Void> update(
             @PathVariable Long userId,
             @Valid @RequestBody UserUpdateDto userUpdateDto
     ) {


### PR DESCRIPTION
## ✔️ 작업 내용

- **누락된 트랜잭션 적용 및 통일**
  - `클래스` 단위에는 `@Transactional(readOnly = true)`를 적용합니다.
  - `메서드` 단위에는 `변경`이 일어나는 로직에만 `@Transactional`을 적용합니다.
- **컨트롤러의 와일드카드 응답 타입 통일**
  - `ResponseEntity<?>` 응답 타입을 `ResponseEntity<Void>`로 통일했습니다.

## 📋 요약

- `트랜잭션` 적용 방식 및 컨트롤러 `응답 타입` 통일

## 🔒 관련 이슈

close #58

## ➕ 기타 사항