### PR TITLE
가게 조합 조회의 잘못된 로직 수정

### DIFF
--- a/src/main/java/wad/seoul_nolgoat/service/search/sort/SortService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/search/sort/SortService.java
@@ -174,7 +174,7 @@ public class SortService {
 
     // 10번째 조합의 총 평점을 기준으로 잡고 그 점수 이상인 조합들을 추출
     private List<GradeSortCombinationDto> filterByBaseTotalGrade(List<GradeSortCombinationDto> gradeCombinations) {
-        double baseTotalGrade = gradeCombinations.get(Math.min(9, gradeCombinations.size())).getTotalGrade();
+        double baseTotalGrade = gradeCombinations.get(Math.min(9, gradeCombinations.size() - 1)).getTotalGrade();
 
         return gradeCombinations.stream()
                 .filter(combination -> combination.getTotalGrade() >= baseTotalGrade)


### PR DESCRIPTION
## ✔️ 작업 내용

- **SortService**
  - 인덱스가 올바르게 적용되도록 수정
    ```java
    double baseTotalGrade = gradeCombinations.get(Math.min(9, gradeCombinations.size() - 1)).getTotalGrade();    
    ```

## 📋 요약

- 인덱스가 올바르게 적용되지 않아 `NullPointerException`이 발생하는 문제 해결

## 🔒 관련 이슈

close #61

## ➕ 기타 사항