### PR TITLE
거리 순으로 가게 조합을 구성할 때, 필요한 전체 경우의 수 줄이기

### DIFF
--- a/src/main/java/wad/seoul_nolgoat/domain/store/StoreRepositoryCustomImpl.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/store/StoreRepositoryCustomImpl.java
@@ -91,7 +91,6 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
     ) {
         List<Tuple> result = jpaQueryFactory
                 .select(store.id, store.kakaoAverageGrade)
-                .distinct()
                 .from(store)
                 .where(
                         buildRangeAndCategoryCondition(
@@ -129,7 +128,7 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
     ) {
         List<Tuple> result = jpaQueryFactory
                 .select(store.id, store.kakaoAverageGrade)
-                .distinct()
+                .distinct() // 카테고리와 가게 타입 조건으로 인해 발생할 수 있는 중복 데이터 제거
                 .from(store)
                 .where(
                         buildRangeAndCategoryAndTypeCondition(
@@ -167,7 +166,6 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
     ) {
         List<Tuple> result = jpaQueryFactory
                 .select(store.id, store.nolgoatAverageGrade)
-                .distinct()
                 .from(store)
                 .where(
                         buildRangeAndCategoryCondition(
@@ -204,7 +202,7 @@ public class StoreRepositoryCustomImpl implements StoreRepositoryCustom {
     ) {
         List<Tuple> result = jpaQueryFactory
                 .select(store.id, store.nolgoatAverageGrade)
-                .distinct()
+                .distinct() // 카테고리와 가게 타입 조건으로 인해 발생할 수 있는 중복 데이터 제거
                 .from(store)
                 .where(
                         buildRangeAndCategoryAndTypeCondition(

--- a/src/main/java/wad/seoul_nolgoat/service/search/dto/StoreForDistanceSortDto.java
+++ b/src/main/java/wad/seoul_nolgoat/service/search/dto/StoreForDistanceSortDto.java
@@ -17,6 +17,8 @@ public class StoreForDistanceSortDto {
     private CoordinateDto coordinate;
     private double kakaoAverageGrade;
     private double nolgoatAverageGrade;
+
+    // Querydsl 빈 생성을 위한 필드
     private Point location;
     private double distance;
 }

--- a/src/main/java/wad/seoul_nolgoat/service/search/dto/StoreForDistanceSortDto.java
+++ b/src/main/java/wad/seoul_nolgoat/service/search/dto/StoreForDistanceSortDto.java
@@ -4,6 +4,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.Point;
 import wad.seoul_nolgoat.web.search.dto.CoordinateDto;
 
 @Getter
@@ -16,4 +17,6 @@ public class StoreForDistanceSortDto {
     private CoordinateDto coordinate;
     private double kakaoAverageGrade;
     private double nolgoatAverageGrade;
+    private Point location;
+    private double distance;
 }

--- a/src/main/java/wad/seoul_nolgoat/service/search/sort/SortService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/search/sort/SortService.java
@@ -48,7 +48,7 @@ public class SortService {
                 totalRounds
         );
 
-        return groupAndShuffleByDistance(tMapFetchedDistanceCombinations);
+        return groupAndShuffleByTMapDistance(tMapFetchedDistanceCombinations);
     }
 
     // 테스트를 위해 접근제어자를 public으로 변경
@@ -214,9 +214,11 @@ public class SortService {
 
     // 거리별로 그룹화
     // 앞 순서의 가게가 상위권에 쏠리지 않도록 그룹내에서 순서를 무작위로 설정
-    private List<DistanceSortCombinationDto> groupAndShuffleByDistance(List<DistanceSortCombinationDto> tMapFetchedDistanceCombinations) {
+    private List<DistanceSortCombinationDto> groupAndShuffleByTMapDistance(List<DistanceSortCombinationDto> tMapFetchedDistanceCombinations) {
         Map<Integer, List<DistanceSortCombinationDto>> groupedByDistance = tMapFetchedDistanceCombinations.stream()
-                .collect(Collectors.groupingBy(combination -> combination.getWalkRouteInfoDto().getTotalDistance()));
+                .collect(Collectors.groupingBy(
+                        combination -> combination.getWalkRouteInfoDto().getTMapTotalDistance())
+                );
         groupedByDistance.forEach((totalDistance, group) -> Collections.shuffle(group));
 
         return groupedByDistance.values().stream()
@@ -359,7 +361,9 @@ public class SortService {
                 }).toList();
 
         return combinations.stream()
-                .sorted(Comparator.comparingInt(combination -> combination.getWalkRouteInfoDto().getTotalDistance()))
+                .sorted(Comparator.comparingInt(
+                        combination -> combination.getWalkRouteInfoDto().getTMapTotalDistance())
+                )
                 .toList();
     }
 

--- a/src/main/java/wad/seoul_nolgoat/service/tMap/TMapService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/tMap/TMapService.java
@@ -165,7 +165,7 @@ public class TMapService {
             WalkRouteInfoDto secondWalkRouteInfo = fetchWalkRouteInfo(pass2, endCoordinate);
 
             return new WalkRouteInfoDto(
-                    firstWalkRouteInfo.getTotalDistance() + secondWalkRouteInfo.getTotalDistance(),
+                    firstWalkRouteInfo.getTMapTotalDistance() + secondWalkRouteInfo.getTMapTotalDistance(),
                     firstWalkRouteInfo.getTotalTime() + secondWalkRouteInfo.getTotalTime()
             );
         }

--- a/src/main/java/wad/seoul_nolgoat/service/tMap/dto/WalkRouteInfoDto.java
+++ b/src/main/java/wad/seoul_nolgoat/service/tMap/dto/WalkRouteInfoDto.java
@@ -7,6 +7,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class WalkRouteInfoDto {
 
-    private final int totalDistance;
+    private final int tMapTotalDistance;
     private final int totalTime;
 }


### PR DESCRIPTION
## ✔️ 작업 내용

- **조합 경우의 수 줄이기**
  - 차수마다 기준이 되는 순번(`30번째`)의 거리 이하인 가게들만 가져오도록 수정했습니다.
  - 기준 순번은 `강남역`과 `종로3가역`을 기준으로 설정했습니다.
- **총거리가 동일한 조합들이, 정해진 순서 때문에 결과에서 제외되던 문제 해결**
  - 총거리별로 그룹화하고, 그룹 내에서는 순서를 무작위로 섞도록 했습니다.

## 📋 요약

거리 기준 조회 개선

## 🔒 관련 이슈

close #63

## ➕ 기타 사항

- 기존에는 평점 기준 조회 시, 2번의 쿼리(기준 평점 조회 + 해당 평점 이상의 가게 조회)가 발생했으나, 이를 하나의 쿼리로 처리하도록 로직을 수정했습니다.