### PR TITLE
TMap API 일일 호출 제한 초과 시, 대체 로직 구현

### DIFF
--- a/src/main/java/wad/seoul_nolgoat/exception/ErrorCode.java
+++ b/src/main/java/wad/seoul_nolgoat/exception/ErrorCode.java
@@ -56,6 +56,8 @@ public enum ErrorCode {
     TMAP_API_CALL_FAILED(HttpStatus.BAD_REQUEST, "MAP001", "TMap API 호출에 실패했습니다."),
     ADDRESS_CONVERSION_FAILED(HttpStatus.BAD_REQUEST, "MAP002", "주소로 변환할 수 없습니다."),
     WALKING_DISTANCE_CALCULATION_FAILED(HttpStatus.BAD_REQUEST, "MAP003", "도보 거리를 계산할 수 없습니다."),
+    API_RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "MAP004", "TMap API 초당 호출 건수를 초과했습니다."),
+    API_QUOTA_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "MAP005", "TMap API 사용 할당량(SLA)을 초과했습니다."),
 
     // 유효성 검사 관련
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "VALIDATION001", "입력값이 유효하지 않습니다."),

--- a/src/main/java/wad/seoul_nolgoat/exception/TMapException.java
+++ b/src/main/java/wad/seoul_nolgoat/exception/TMapException.java
@@ -1,0 +1,14 @@
+package wad.seoul_nolgoat.exception;
+
+import lombok.Getter;
+
+@Getter
+public class TMapException extends ApiException {
+
+    private final ErrorCode errorCode;
+
+    public TMapException(ErrorCode errorCode) {
+        super(errorCode);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/wad/seoul_nolgoat/service/search/SearchService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/search/SearchService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import wad.seoul_nolgoat.domain.store.StoreCategory;
 import wad.seoul_nolgoat.exception.ApiException;
+import wad.seoul_nolgoat.exception.TMapException;
 import wad.seoul_nolgoat.service.search.dto.SortConditionDto;
 import wad.seoul_nolgoat.service.search.dto.StoreForPossibleCategoriesDto;
 import wad.seoul_nolgoat.service.search.filter.FilterService;
@@ -393,7 +394,7 @@ public class SearchService {
                             return combination;
                         }
                         throw new ApiException(INVALID_GATHERING_ROUND);
-                    } catch (ApiException e) {
+                    } catch (TMapException e) {
                         log.error("TMap Error : {}", e.getMessage());
                         int totalDistance = DistanceCalculator.calculateTotalDistanceForGradeWithFallback(
                                 totalRounds,

--- a/src/main/java/wad/seoul_nolgoat/service/search/dto/DistanceSortCombinationDto.java
+++ b/src/main/java/wad/seoul_nolgoat/service/search/dto/DistanceSortCombinationDto.java
@@ -15,7 +15,7 @@ public class DistanceSortCombinationDto {
     private final int totalRounds;
 
     @Setter
-    private double totalDistance;
+    private int totalDistance;
 
     public DistanceSortCombinationDto(
             StoreForDistanceSortDto firstStore,

--- a/src/main/java/wad/seoul_nolgoat/service/search/sort/DistanceCalculator.java
+++ b/src/main/java/wad/seoul_nolgoat/service/search/sort/DistanceCalculator.java
@@ -11,9 +11,10 @@ public class DistanceCalculator {
 
     public static final double EARTH_RADIUS_KM = 6371.0;
 
+    private static final int METER_CONVERSION_FACTOR = 1000;
     private static final double TO_RADIAN = Math.PI / 180;
 
-    public static double calculateTotalDistance(
+    public static int calculateTotalDistance(
             StoreForDistanceSortDto firstStore,
             StoreForDistanceSortDto secondStore,
             StoreForDistanceSortDto thirdStore,
@@ -23,12 +24,14 @@ public class DistanceCalculator {
         CoordinateDto secondCoordinate = secondStore.getCoordinate();
         CoordinateDto thirdCoordinate = thirdStore.getCoordinate();
 
-        return calculateDistance(startCoordinate, firstCoordinate)
-                + calculateDistance(firstCoordinate, secondCoordinate)
-                + calculateDistance(secondCoordinate, thirdCoordinate);
+        return (int) (
+                (calculateDistance(startCoordinate, firstCoordinate)
+                        + calculateDistance(firstCoordinate, secondCoordinate)
+                        + calculateDistance(secondCoordinate, thirdCoordinate)) * METER_CONVERSION_FACTOR
+        );
     }
 
-    public static double calculateTotalDistance(
+    public static int calculateTotalDistance(
             StoreForDistanceSortDto firstStore,
             StoreForDistanceSortDto secondStore,
             CoordinateDto startCoordinate
@@ -36,17 +39,19 @@ public class DistanceCalculator {
         CoordinateDto firstCoordinate = firstStore.getCoordinate();
         CoordinateDto secondCoordinate = secondStore.getCoordinate();
 
-        return calculateDistance(startCoordinate, firstCoordinate)
-                + calculateDistance(firstCoordinate, secondCoordinate);
+        return (int) (
+                (calculateDistance(startCoordinate, firstCoordinate)
+                        + calculateDistance(firstCoordinate, secondCoordinate)) * METER_CONVERSION_FACTOR
+        );
     }
 
-    public static double calculateTotalDistance(StoreForDistanceSortDto firstStore, CoordinateDto startCoordinate) {
+    public static int calculateTotalDistance(StoreForDistanceSortDto firstStore, CoordinateDto startCoordinate) {
         CoordinateDto firstCoordinate = firstStore.getCoordinate();
 
-        return calculateDistance(startCoordinate, firstCoordinate);
+        return (int) (calculateDistance(startCoordinate, firstCoordinate) * METER_CONVERSION_FACTOR);
     }
 
-    public static double calculateTotalDistanceForGradeWithFallback(
+    public static int calculateTotalDistanceForGradeWithFallback(
             int totalRounds,
             CombinationDto combinationDto,
             CoordinateDto startCoordinate
@@ -55,19 +60,23 @@ public class DistanceCalculator {
             CoordinateDto firstCoordinate = combinationDto.getFirstStore().getCoordinate();
             CoordinateDto secondCoordinate = combinationDto.getSecondStore().getCoordinate();
             CoordinateDto thirdCoordinate = combinationDto.getThirdStore().getCoordinate();
-            return calculateDistance(startCoordinate, firstCoordinate)
-                    + calculateDistance(firstCoordinate, secondCoordinate)
-                    + calculateDistance(secondCoordinate, thirdCoordinate);
+            return (int) (
+                    (calculateDistance(startCoordinate, firstCoordinate)
+                            + calculateDistance(firstCoordinate, secondCoordinate)
+                            + calculateDistance(secondCoordinate, thirdCoordinate)) * METER_CONVERSION_FACTOR
+            );
         }
         if (totalRounds == 2) {
             CoordinateDto firstCoordinate = combinationDto.getFirstStore().getCoordinate();
             CoordinateDto secondCoordinate = combinationDto.getSecondStore().getCoordinate();
-            return calculateDistance(startCoordinate, firstCoordinate)
-                    + calculateDistance(firstCoordinate, secondCoordinate);
+            return (int) (
+                    (calculateDistance(startCoordinate, firstCoordinate)
+                            + calculateDistance(firstCoordinate, secondCoordinate)) * METER_CONVERSION_FACTOR
+            );
         }
         if (totalRounds == 1) {
             CoordinateDto firstCoordinate = combinationDto.getFirstStore().getCoordinate();
-            return calculateDistance(startCoordinate, firstCoordinate);
+            return (int) (calculateDistance(startCoordinate, firstCoordinate) * METER_CONVERSION_FACTOR);
         }
         throw new ApiException(INVALID_GATHERING_ROUND);
     }

--- a/src/main/java/wad/seoul_nolgoat/service/search/sort/DistanceCalculator.java
+++ b/src/main/java/wad/seoul_nolgoat/service/search/sort/DistanceCalculator.java
@@ -1,17 +1,19 @@
 package wad.seoul_nolgoat.service.search.sort;
 
-import org.springframework.stereotype.Component;
+import wad.seoul_nolgoat.exception.ApiException;
 import wad.seoul_nolgoat.service.search.dto.StoreForDistanceSortDto;
 import wad.seoul_nolgoat.web.search.dto.CoordinateDto;
+import wad.seoul_nolgoat.web.search.dto.response.CombinationDto;
 
-@Component
+import static wad.seoul_nolgoat.exception.ErrorCode.INVALID_GATHERING_ROUND;
+
 public class DistanceCalculator {
 
     public static final double EARTH_RADIUS_KM = 6371.0;
 
     private static final double TO_RADIAN = Math.PI / 180;
 
-    public double calculateTotalDistance(
+    public static double calculateTotalDistance(
             StoreForDistanceSortDto firstStore,
             StoreForDistanceSortDto secondStore,
             StoreForDistanceSortDto thirdStore,
@@ -26,7 +28,7 @@ public class DistanceCalculator {
                 + calculateDistance(secondCoordinate, thirdCoordinate);
     }
 
-    public double calculateTotalDistance(
+    public static double calculateTotalDistance(
             StoreForDistanceSortDto firstStore,
             StoreForDistanceSortDto secondStore,
             CoordinateDto startCoordinate
@@ -38,13 +40,39 @@ public class DistanceCalculator {
                 + calculateDistance(firstCoordinate, secondCoordinate);
     }
 
-    public double calculateTotalDistance(StoreForDistanceSortDto firstStore, CoordinateDto startCoordinate) {
+    public static double calculateTotalDistance(StoreForDistanceSortDto firstStore, CoordinateDto startCoordinate) {
         CoordinateDto firstCoordinate = firstStore.getCoordinate();
 
         return calculateDistance(startCoordinate, firstCoordinate);
     }
 
-    private double calculateDistance(CoordinateDto firstCoordinate, CoordinateDto secondCoordinate) {
+    public static double calculateTotalDistanceForGradeWithFallback(
+            int totalRounds,
+            CombinationDto combinationDto,
+            CoordinateDto startCoordinate
+    ) {
+        if (totalRounds == 3) {
+            CoordinateDto firstCoordinate = combinationDto.getFirstStore().getCoordinate();
+            CoordinateDto secondCoordinate = combinationDto.getSecondStore().getCoordinate();
+            CoordinateDto thirdCoordinate = combinationDto.getThirdStore().getCoordinate();
+            return calculateDistance(startCoordinate, firstCoordinate)
+                    + calculateDistance(firstCoordinate, secondCoordinate)
+                    + calculateDistance(secondCoordinate, thirdCoordinate);
+        }
+        if (totalRounds == 2) {
+            CoordinateDto firstCoordinate = combinationDto.getFirstStore().getCoordinate();
+            CoordinateDto secondCoordinate = combinationDto.getSecondStore().getCoordinate();
+            return calculateDistance(startCoordinate, firstCoordinate)
+                    + calculateDistance(firstCoordinate, secondCoordinate);
+        }
+        if (totalRounds == 1) {
+            CoordinateDto firstCoordinate = combinationDto.getFirstStore().getCoordinate();
+            return calculateDistance(startCoordinate, firstCoordinate);
+        }
+        throw new ApiException(INVALID_GATHERING_ROUND);
+    }
+
+    private static double calculateDistance(CoordinateDto firstCoordinate, CoordinateDto secondCoordinate) {
         double firstLatitude = firstCoordinate.getLatitude();
         double firstLongitude = firstCoordinate.getLongitude();
         double secondLatitude = secondCoordinate.getLatitude();

--- a/src/main/java/wad/seoul_nolgoat/service/search/sort/DistanceCalculator.java
+++ b/src/main/java/wad/seoul_nolgoat/service/search/sort/DistanceCalculator.java
@@ -1,11 +1,8 @@
 package wad.seoul_nolgoat.service.search.sort;
 
-import wad.seoul_nolgoat.exception.ApiException;
 import wad.seoul_nolgoat.service.search.dto.StoreForDistanceSortDto;
 import wad.seoul_nolgoat.web.search.dto.CoordinateDto;
 import wad.seoul_nolgoat.web.search.dto.response.CombinationDto;
-
-import static wad.seoul_nolgoat.exception.ErrorCode.INVALID_GATHERING_ROUND;
 
 public class DistanceCalculator {
 
@@ -74,11 +71,10 @@ public class DistanceCalculator {
                             + calculateDistance(firstCoordinate, secondCoordinate)) * METER_CONVERSION_FACTOR
             );
         }
-        if (totalRounds == 1) {
-            CoordinateDto firstCoordinate = combinationDto.getFirstStore().getCoordinate();
-            return (int) (calculateDistance(startCoordinate, firstCoordinate) * METER_CONVERSION_FACTOR);
-        }
-        throw new ApiException(INVALID_GATHERING_ROUND);
+
+        // 1차인 경우
+        CoordinateDto firstCoordinate = combinationDto.getFirstStore().getCoordinate();
+        return (int) (calculateDistance(startCoordinate, firstCoordinate) * METER_CONVERSION_FACTOR);
     }
 
     private static double calculateDistance(CoordinateDto firstCoordinate, CoordinateDto secondCoordinate) {

--- a/src/main/java/wad/seoul_nolgoat/service/search/sort/SortService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/search/sort/SortService.java
@@ -12,8 +12,6 @@ import wad.seoul_nolgoat.web.search.dto.CoordinateDto;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static wad.seoul_nolgoat.exception.ErrorCode.INVALID_GATHERING_ROUND;
-
 @Slf4j
 @RequiredArgsConstructor
 @Service
@@ -78,13 +76,12 @@ public class SortService {
                     sortConditionDto.getStartCoordinate()
             );
         }
-        if (totalRounds == SearchService.ONE_ROUND) {
-            return createDistanceCombinationsForOneRound(
-                    sortConditionDto.getFirstFilteredStores(),
-                    sortConditionDto.getStartCoordinate()
-            );
-        }
-        throw new ApiException(INVALID_GATHERING_ROUND);
+
+        // 1차인 경우
+        return createDistanceCombinationsForOneRound(
+                sortConditionDto.getFirstFilteredStores(),
+                sortConditionDto.getStartCoordinate()
+        );
     }
 
     private List<GradeSortCombinationDto> generateGradeCombinations(
@@ -104,10 +101,9 @@ public class SortService {
                     sortConditionDto.getSecondFilteredStores()
             );
         }
-        if (totalRounds == SearchService.ONE_ROUND) {
-            return createGradeCombinationsForOneRound(sortConditionDto.getFirstFilteredStores());
-        }
-        throw new ApiException(INVALID_GATHERING_ROUND);
+
+        // 1차인 경우
+        return createGradeCombinationsForOneRound(sortConditionDto.getFirstFilteredStores());
     }
 
     private List<GradeSortCombinationDto> createGradeCombinationsForThreeRounds(
@@ -366,15 +362,14 @@ public class SortService {
                                 )
                         );
                     }
-                    if (totalRounds == SearchService.ONE_ROUND) {
-                        CoordinateDto endCoordinate = combination.getFirstStore().getCoordinate();
 
-                        return new DistanceSortCombinationDto(
-                                combination.getFirstStore(),
-                                tMapService.fetchFullPathWalkRouteInfo(startCoordinate, endCoordinate)
-                        );
-                    }
-                    throw new ApiException(INVALID_GATHERING_ROUND);
+                    // 1차인 경우
+                    CoordinateDto endCoordinate = combination.getFirstStore().getCoordinate();
+
+                    return new DistanceSortCombinationDto(
+                            combination.getFirstStore(),
+                            tMapService.fetchFullPathWalkRouteInfo(startCoordinate, endCoordinate)
+                    );
                 }).toList();
 
         return combinations.stream()

--- a/src/main/java/wad/seoul_nolgoat/service/search/sort/SortService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/search/sort/SortService.java
@@ -236,7 +236,7 @@ public class SortService {
     // 직선 거리 계산 결과로 그룹화
     // 앞 순서의 가게가 상위권에 쏠리지 않도록 그룹내에서 순서를 무작위로 설정
     private List<DistanceSortCombinationDto> groupAndShuffleByDistance(List<DistanceSortCombinationDto> combinationsUnderBaseDistance) {
-        Map<Double, List<DistanceSortCombinationDto>> groupedByDistance = combinationsUnderBaseDistance.stream()
+        Map<Integer, List<DistanceSortCombinationDto>> groupedByDistance = combinationsUnderBaseDistance.stream()
                 .collect(Collectors.groupingBy(DistanceSortCombinationDto::getTotalDistance));
         groupedByDistance.forEach((totalDistance, group) -> Collections.shuffle(group));
 
@@ -270,7 +270,7 @@ public class SortService {
                             secondStore,
                             thirdStore
                     );
-                    double totalDistance = DistanceCalculator.calculateTotalDistance(
+                    int totalDistance = DistanceCalculator.calculateTotalDistance(
                             distanceSortCombinationDto.getFirstStore(),
                             distanceSortCombinationDto.getSecondStore(),
                             distanceSortCombinationDto.getThirdStore(),
@@ -300,7 +300,7 @@ public class SortService {
                         firstStore,
                         secondStore
                 );
-                double totalDistance = DistanceCalculator.calculateTotalDistance(
+                int totalDistance = DistanceCalculator.calculateTotalDistance(
                         distanceSortCombinationDto.getFirstStore(),
                         distanceSortCombinationDto.getSecondStore(),
                         coordinateDto);
@@ -319,7 +319,7 @@ public class SortService {
         List<DistanceSortCombinationDto> combinations = new ArrayList<>();
         for (StoreForDistanceSortDto firstStore : firstStores) {
             DistanceSortCombinationDto distanceSortCombinationDto = new DistanceSortCombinationDto(firstStore);
-            double totalDistance = DistanceCalculator.calculateTotalDistance(
+            int totalDistance = DistanceCalculator.calculateTotalDistance(
                     distanceSortCombinationDto.getFirstStore(), coordinateDto);
             distanceSortCombinationDto.setTotalDistance(totalDistance);
             combinations.add(distanceSortCombinationDto);

--- a/src/main/java/wad/seoul_nolgoat/service/search/sort/SortService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/search/sort/SortService.java
@@ -23,7 +23,6 @@ public class SortService {
     private static final int TOTAL_DISTANCE_SORT_MAX_RESULT_COUNT = 20;
 
     private final TMapService tMapService;
-    private final DistanceCalculator distanceCalculator;
 
     public List<GradeSortCombinationDto> sortStoresByGrade(SortConditionDto<StoreForGradeSortDto> sortConditionDto) {
         int totalRounds = sortConditionDto.getTotalRounds();
@@ -271,7 +270,7 @@ public class SortService {
                             secondStore,
                             thirdStore
                     );
-                    double totalDistance = distanceCalculator.calculateTotalDistance(
+                    double totalDistance = DistanceCalculator.calculateTotalDistance(
                             distanceSortCombinationDto.getFirstStore(),
                             distanceSortCombinationDto.getSecondStore(),
                             distanceSortCombinationDto.getThirdStore(),
@@ -291,7 +290,6 @@ public class SortService {
             List<StoreForDistanceSortDto> secondStores,
             CoordinateDto coordinateDto
     ) {
-        DistanceCalculator distanceCalculator = new DistanceCalculator();
         List<DistanceSortCombinationDto> combinations = new ArrayList<>();
         for (StoreForDistanceSortDto firstStore : firstStores) {
             for (StoreForDistanceSortDto secondStore : secondStores) {
@@ -302,7 +300,7 @@ public class SortService {
                         firstStore,
                         secondStore
                 );
-                double totalDistance = distanceCalculator.calculateTotalDistance(
+                double totalDistance = DistanceCalculator.calculateTotalDistance(
                         distanceSortCombinationDto.getFirstStore(),
                         distanceSortCombinationDto.getSecondStore(),
                         coordinateDto);
@@ -318,11 +316,10 @@ public class SortService {
             List<StoreForDistanceSortDto> firstStores,
             CoordinateDto coordinateDto
     ) {
-        DistanceCalculator distanceCalculator = new DistanceCalculator();
         List<DistanceSortCombinationDto> combinations = new ArrayList<>();
         for (StoreForDistanceSortDto firstStore : firstStores) {
             DistanceSortCombinationDto distanceSortCombinationDto = new DistanceSortCombinationDto(firstStore);
-            double totalDistance = distanceCalculator.calculateTotalDistance(
+            double totalDistance = DistanceCalculator.calculateTotalDistance(
                     distanceSortCombinationDto.getFirstStore(), coordinateDto);
             distanceSortCombinationDto.setTotalDistance(totalDistance);
             combinations.add(distanceSortCombinationDto);

--- a/src/main/java/wad/seoul_nolgoat/service/search/sort/SortService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/search/sort/SortService.java
@@ -224,7 +224,7 @@ public class SortService {
     private List<DistanceSortCombinationDto> groupAndShuffleByTMapDistance(List<DistanceSortCombinationDto> tMapFetchedDistanceCombinations) {
         Map<Integer, List<DistanceSortCombinationDto>> groupedByDistance = tMapFetchedDistanceCombinations.stream()
                 .collect(Collectors.groupingBy(
-                        combination -> combination.getWalkRouteInfoDto().getTMapTotalDistance())
+                        combination -> combination.getWalkRouteInfoDto().getTotalDistance())
                 );
         groupedByDistance.forEach((totalDistance, group) -> Collections.shuffle(group));
 
@@ -379,7 +379,7 @@ public class SortService {
 
         return combinations.stream()
                 .sorted(Comparator.comparingInt(
-                        combination -> combination.getWalkRouteInfoDto().getTMapTotalDistance())
+                        combination -> combination.getWalkRouteInfoDto().getTotalDistance())
                 )
                 .toList();
     }

--- a/src/main/java/wad/seoul_nolgoat/service/tMap/TMapService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/tMap/TMapService.java
@@ -26,6 +26,8 @@ import static wad.seoul_nolgoat.exception.ErrorCode.*;
 @Service
 public class TMapService {
 
+    public static final int INVALID_TIME = -1;
+
     private static final String START_NAME = "%EC%B6%9C%EB%B0%9C%EC%A7%80%EC%A0%90";
     private static final String END_NAME = "%EB%8F%84%EC%B0%A9%EC%A7%80%EC%A0%90";
     private static final String SEARCH_OPTION = "10";

--- a/src/main/java/wad/seoul_nolgoat/service/tMap/TMapService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/tMap/TMapService.java
@@ -11,7 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
-import wad.seoul_nolgoat.exception.ApiException;
+import wad.seoul_nolgoat.exception.TMapException;
 import wad.seoul_nolgoat.service.tMap.dto.WalkRouteInfoDto;
 import wad.seoul_nolgoat.web.search.dto.CoordinateDto;
 
@@ -132,15 +132,15 @@ public class TMapService {
                     return new WalkRouteInfoDto(properties.get(TOTAL_DISTANCE_PATH).asInt(), properties.get(TOTAL_TIME_PATH).asInt());
                 }
             }
-            throw new ApiException(WALKING_DISTANCE_CALCULATION_FAILED);
+            throw new TMapException(WALKING_DISTANCE_CALCULATION_FAILED);
         } catch (HttpClientErrorException.TooManyRequests e) {
             String body = e.getResponseBodyAsString();
             if (body.contains("QUOTA_EXCEEDED")) {
-                throw new ApiException(API_QUOTA_EXCEEDED);
+                throw new TMapException(API_QUOTA_EXCEEDED);
             }
-            throw new ApiException(API_RATE_LIMIT_EXCEEDED);
+            throw new TMapException(API_RATE_LIMIT_EXCEEDED);
         } catch (Exception e) {
-            throw new ApiException(TMAP_API_CALL_FAILED);
+            throw new TMapException(TMAP_API_CALL_FAILED);
         }
     }
 

--- a/src/main/java/wad/seoul_nolgoat/service/tMap/TMapService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/tMap/TMapService.java
@@ -173,7 +173,7 @@ public class TMapService {
             WalkRouteInfoDto secondWalkRouteInfo = fetchWalkRouteInfo(pass2, endCoordinate);
 
             return new WalkRouteInfoDto(
-                    firstWalkRouteInfo.getTMapTotalDistance() + secondWalkRouteInfo.getTMapTotalDistance(),
+                    firstWalkRouteInfo.getTotalDistance() + secondWalkRouteInfo.getTotalDistance(),
                     firstWalkRouteInfo.getTotalTime() + secondWalkRouteInfo.getTotalTime()
             );
         }

--- a/src/main/java/wad/seoul_nolgoat/service/tMap/TMapService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/tMap/TMapService.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import wad.seoul_nolgoat.exception.ApiException;
 import wad.seoul_nolgoat.service.tMap.dto.WalkRouteInfoDto;
@@ -19,8 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static wad.seoul_nolgoat.exception.ErrorCode.TMAP_API_CALL_FAILED;
-import static wad.seoul_nolgoat.exception.ErrorCode.WALKING_DISTANCE_CALCULATION_FAILED;
+import static wad.seoul_nolgoat.exception.ErrorCode.*;
 
 @RequiredArgsConstructor
 @Service
@@ -131,6 +131,12 @@ public class TMapService {
                 }
             }
             throw new ApiException(WALKING_DISTANCE_CALCULATION_FAILED);
+        } catch (HttpClientErrorException.TooManyRequests e) {
+            String body = e.getResponseBodyAsString();
+            if (body.contains("QUOTA_EXCEEDED")) {
+                throw new ApiException(API_QUOTA_EXCEEDED);
+            }
+            throw new ApiException(API_RATE_LIMIT_EXCEEDED);
         } catch (Exception e) {
             throw new ApiException(TMAP_API_CALL_FAILED);
         }

--- a/src/main/java/wad/seoul_nolgoat/service/tMap/dto/WalkRouteInfoDto.java
+++ b/src/main/java/wad/seoul_nolgoat/service/tMap/dto/WalkRouteInfoDto.java
@@ -7,6 +7,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class WalkRouteInfoDto {
 
-    private final int tMapTotalDistance;
+    private final int totalDistance;
     private final int totalTime;
 }

--- a/src/main/java/wad/seoul_nolgoat/util/mapper/CombinationMapper.java
+++ b/src/main/java/wad/seoul_nolgoat/util/mapper/CombinationMapper.java
@@ -1,14 +1,11 @@
 package wad.seoul_nolgoat.util.mapper;
 
-import wad.seoul_nolgoat.exception.ApiException;
 import wad.seoul_nolgoat.service.search.SearchService;
 import wad.seoul_nolgoat.service.search.dto.DistanceSortCombinationDto;
 import wad.seoul_nolgoat.service.search.dto.GradeSortCombinationDto;
 import wad.seoul_nolgoat.service.tMap.TMapService;
 import wad.seoul_nolgoat.service.tMap.dto.WalkRouteInfoDto;
 import wad.seoul_nolgoat.web.search.dto.response.CombinationDto;
-
-import static wad.seoul_nolgoat.exception.ErrorCode.INVALID_GATHERING_ROUND;
 
 public class CombinationMapper {
 
@@ -32,13 +29,12 @@ public class CombinationMapper {
                     walkRouteInfoDto
             );
         }
-        if (distanceSortCombinationDto.getTotalRounds() == SearchService.ONE_ROUND) {
-            return new CombinationDto(
-                    StoreMapper.toStoreForCombinationDto(distanceSortCombinationDto.getFirstStore()),
-                    walkRouteInfoDto
-            );
-        }
-        throw new ApiException(INVALID_GATHERING_ROUND);
+
+        // 1차인 경우
+        return new CombinationDto(
+                StoreMapper.toStoreForCombinationDto(distanceSortCombinationDto.getFirstStore()),
+                walkRouteInfoDto
+        );
     }
 
     public static CombinationDto toCombinationDto(GradeSortCombinationDto gradeSortCombinationDto) {
@@ -55,11 +51,10 @@ public class CombinationMapper {
                     StoreMapper.toStoreForCombinationDto(gradeSortCombinationDto.getSecondStore())
             );
         }
-        if (gradeSortCombinationDto.getTotalRounds() == SearchService.ONE_ROUND) {
-            return new CombinationDto(
-                    StoreMapper.toStoreForCombinationDto(gradeSortCombinationDto.getFirstStore())
-            );
-        }
-        throw new ApiException(INVALID_GATHERING_ROUND);
+
+        // 1차인 경우
+        return new CombinationDto(
+                StoreMapper.toStoreForCombinationDto(gradeSortCombinationDto.getFirstStore())
+        );
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/util/mapper/CombinationMapper.java
+++ b/src/main/java/wad/seoul_nolgoat/util/mapper/CombinationMapper.java
@@ -4,6 +4,7 @@ import wad.seoul_nolgoat.exception.ApiException;
 import wad.seoul_nolgoat.service.search.SearchService;
 import wad.seoul_nolgoat.service.search.dto.DistanceSortCombinationDto;
 import wad.seoul_nolgoat.service.search.dto.GradeSortCombinationDto;
+import wad.seoul_nolgoat.service.tMap.TMapService;
 import wad.seoul_nolgoat.service.tMap.dto.WalkRouteInfoDto;
 import wad.seoul_nolgoat.web.search.dto.response.CombinationDto;
 
@@ -14,7 +15,7 @@ public class CombinationMapper {
     public static CombinationDto toCombinationDto(DistanceSortCombinationDto distanceSortCombinationDto) {
         WalkRouteInfoDto walkRouteInfoDto = distanceSortCombinationDto.getWalkRouteInfoDto();
         if (walkRouteInfoDto == null) {
-            walkRouteInfoDto = new WalkRouteInfoDto(distanceSortCombinationDto.getTotalDistance(), -1);
+            walkRouteInfoDto = new WalkRouteInfoDto(distanceSortCombinationDto.getTotalDistance(), TMapService.INVALID_TIME);
         }
         if (distanceSortCombinationDto.getTotalRounds() == SearchService.THREE_ROUND) {
             return new CombinationDto(

--- a/src/main/java/wad/seoul_nolgoat/util/mapper/CombinationMapper.java
+++ b/src/main/java/wad/seoul_nolgoat/util/mapper/CombinationMapper.java
@@ -14,7 +14,7 @@ public class CombinationMapper {
     public static CombinationDto toCombinationDto(DistanceSortCombinationDto distanceSortCombinationDto) {
         WalkRouteInfoDto walkRouteInfoDto = distanceSortCombinationDto.getWalkRouteInfoDto();
         if (walkRouteInfoDto == null) {
-            walkRouteInfoDto = new WalkRouteInfoDto((int) (distanceSortCombinationDto.getTotalDistance() * 1000), -1);
+            walkRouteInfoDto = new WalkRouteInfoDto(distanceSortCombinationDto.getTotalDistance(), -1);
         }
         if (distanceSortCombinationDto.getTotalRounds() == SearchService.THREE_ROUND) {
             return new CombinationDto(

--- a/src/main/java/wad/seoul_nolgoat/util/mapper/CombinationMapper.java
+++ b/src/main/java/wad/seoul_nolgoat/util/mapper/CombinationMapper.java
@@ -4,6 +4,7 @@ import wad.seoul_nolgoat.exception.ApiException;
 import wad.seoul_nolgoat.service.search.SearchService;
 import wad.seoul_nolgoat.service.search.dto.DistanceSortCombinationDto;
 import wad.seoul_nolgoat.service.search.dto.GradeSortCombinationDto;
+import wad.seoul_nolgoat.service.tMap.dto.WalkRouteInfoDto;
 import wad.seoul_nolgoat.web.search.dto.response.CombinationDto;
 
 import static wad.seoul_nolgoat.exception.ErrorCode.INVALID_GATHERING_ROUND;
@@ -11,25 +12,29 @@ import static wad.seoul_nolgoat.exception.ErrorCode.INVALID_GATHERING_ROUND;
 public class CombinationMapper {
 
     public static CombinationDto toCombinationDto(DistanceSortCombinationDto distanceSortCombinationDto) {
+        WalkRouteInfoDto walkRouteInfoDto = distanceSortCombinationDto.getWalkRouteInfoDto();
+        if (walkRouteInfoDto == null) {
+            walkRouteInfoDto = new WalkRouteInfoDto((int) (distanceSortCombinationDto.getTotalDistance() * 1000), -1);
+        }
         if (distanceSortCombinationDto.getTotalRounds() == SearchService.THREE_ROUND) {
             return new CombinationDto(
                     StoreMapper.toStoreForCombinationDto(distanceSortCombinationDto.getFirstStore()),
                     StoreMapper.toStoreForCombinationDto(distanceSortCombinationDto.getSecondStore()),
                     StoreMapper.toStoreForCombinationDto(distanceSortCombinationDto.getThirdStore()),
-                    distanceSortCombinationDto.getWalkRouteInfoDto()
+                    walkRouteInfoDto
             );
         }
         if (distanceSortCombinationDto.getTotalRounds() == SearchService.TWO_ROUND) {
             return new CombinationDto(
                     StoreMapper.toStoreForCombinationDto(distanceSortCombinationDto.getFirstStore()),
                     StoreMapper.toStoreForCombinationDto(distanceSortCombinationDto.getSecondStore()),
-                    distanceSortCombinationDto.getWalkRouteInfoDto()
+                    walkRouteInfoDto
             );
         }
         if (distanceSortCombinationDto.getTotalRounds() == SearchService.ONE_ROUND) {
             return new CombinationDto(
                     StoreMapper.toStoreForCombinationDto(distanceSortCombinationDto.getFirstStore()),
-                    distanceSortCombinationDto.getWalkRouteInfoDto()
+                    walkRouteInfoDto
             );
         }
         throw new ApiException(INVALID_GATHERING_ROUND);


### PR DESCRIPTION
## ✔️ 작업 내용

- **TMap 도보 경로 계산 API 사용 횟수 초과 처리**
  - `TMap` API를 모두 사용하면, 직선거리 계산으로 자동 대체하도록 수정했습니다.
- **TMap 관련 커스텀 예외 추가**
  - `TMap` API 에러를 별도로 처리할 수 있도록 `TMapException`을 구현했습니다.
  - 예외는 기존에 있는 `ApiException`을 상속하여 공통 에러 처리 흐름을 유지했습니다.

## 📋 요약

- `TMap` API 사용 횟수 초과 시, 직선 거리 계산 로직 추가
- `TMapException` 도입으로 `TMap` 에러 관리 개선

## 🔒 관련 이슈

close #65

## ➕ 기타 사항