### PR TITLE
총거리 기준으로 조합 조회 시, 오름차순 정렬이 적용되지 않는 문제 해결

### DIFF
--- a/src/main/java/wad/seoul_nolgoat/service/search/sort/SortService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/search/sort/SortService.java
@@ -3,7 +3,7 @@ package wad.seoul_nolgoat.service.search.sort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import wad.seoul_nolgoat.exception.ApiException;
+import wad.seoul_nolgoat.exception.TMapException;
 import wad.seoul_nolgoat.service.search.SearchService;
 import wad.seoul_nolgoat.service.search.dto.*;
 import wad.seoul_nolgoat.service.tMap.TMapService;
@@ -48,7 +48,7 @@ public class SortService {
                     combinationsUnderBaseDistance,
                     totalRounds
             );
-        } catch (ApiException e) {
+        } catch (TMapException e) {
             log.error("TMap Error : {}", e.getMessage());
             return groupAndShuffleByDistance(combinationsUnderBaseDistance);
         }

--- a/src/main/java/wad/seoul_nolgoat/service/search/sort/SortService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/search/sort/SortService.java
@@ -207,7 +207,13 @@ public class SortService {
     // 앞 순서의 가게가 상위권에 쏠리지 않도록 그룹내에서 순서를 무작위로 설정
     private List<GradeSortCombinationDto> groupAndShuffleByGrade(List<GradeSortCombinationDto> filteredGradeCombinations) {
         Map<Double, List<GradeSortCombinationDto>> groupedByGrade = filteredGradeCombinations.stream()
-                .collect(Collectors.groupingBy(GradeSortCombinationDto::getTotalGrade, LinkedHashMap::new, Collectors.toList()));
+                .collect(
+                        Collectors.groupingBy(
+                                GradeSortCombinationDto::getTotalGrade,
+                                LinkedHashMap::new,
+                                Collectors.toList()
+                        )
+                );
         groupedByGrade.forEach((totalGrade, group) -> Collections.shuffle(group));
 
         return groupedByGrade.values().stream()

--- a/src/main/java/wad/seoul_nolgoat/service/search/sort/SortService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/search/sort/SortService.java
@@ -219,8 +219,12 @@ public class SortService {
     // 앞 순서의 가게가 상위권에 쏠리지 않도록 그룹내에서 순서를 무작위로 설정
     private List<DistanceSortCombinationDto> groupAndShuffleByTMapDistance(List<DistanceSortCombinationDto> tMapFetchedDistanceCombinations) {
         Map<Integer, List<DistanceSortCombinationDto>> groupedByDistance = tMapFetchedDistanceCombinations.stream()
-                .collect(Collectors.groupingBy(
-                        combination -> combination.getWalkRouteInfoDto().getTotalDistance())
+                .collect(
+                        Collectors.groupingBy(
+                                combination -> combination.getWalkRouteInfoDto().getTotalDistance(),
+                                LinkedHashMap::new,
+                                Collectors.toList()
+                        )
                 );
         groupedByDistance.forEach((totalDistance, group) -> Collections.shuffle(group));
 
@@ -233,7 +237,13 @@ public class SortService {
     // 앞 순서의 가게가 상위권에 쏠리지 않도록 그룹내에서 순서를 무작위로 설정
     private List<DistanceSortCombinationDto> groupAndShuffleByDistance(List<DistanceSortCombinationDto> combinationsUnderBaseDistance) {
         Map<Integer, List<DistanceSortCombinationDto>> groupedByDistance = combinationsUnderBaseDistance.stream()
-                .collect(Collectors.groupingBy(DistanceSortCombinationDto::getTotalDistance));
+                .collect(
+                        Collectors.groupingBy(
+                                DistanceSortCombinationDto::getTotalDistance,
+                                LinkedHashMap::new,
+                                Collectors.toList()
+                        )
+                );
         groupedByDistance.forEach((totalDistance, group) -> Collections.shuffle(group));
 
         return groupedByDistance.values().stream()


### PR DESCRIPTION
## ✔️ 작업 내용

- **SortService**
  - 총거리 기준으로 정렬 후, 같은 결과끼리는 그룹화하고, 그룹 내 항목들을 무작위로 섞는 과정에서 오름차순 정렬이 제대로 적용되도록 수정했습니다.

## 📋 요약

- 총거리 기준으로 조합 조회 시, 오름차순 정렬이 적용되지 않는 문제 해결

## 🔒 관련 이슈

close #72

## ➕ 기타 사항

- `ApiException`을 `TMapException`으로 변경하여 TMap API에서 발생하는 예외를 정확하게 처리하도록 수정했습니다.