### PR TITLE
fix: 가능한 카테고리에 놀거리 항목이 나오지 않는 오류 해결

### DIFF
--- a/src/main/java/wad/seoul_nolgoat/service/search/SearchService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/search/SearchService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import wad.seoul_nolgoat.domain.store.StoreCategory;
+import wad.seoul_nolgoat.domain.store.StoreType;
 import wad.seoul_nolgoat.exception.ApiException;
 import wad.seoul_nolgoat.exception.TMapException;
 import wad.seoul_nolgoat.service.search.dto.SortConditionDto;
@@ -75,6 +76,10 @@ public class SearchService {
 
         Set<String> possibleCategories = new HashSet<>();
         for (StoreForPossibleCategoriesDto untokenizedCategory : untokenizedCategories) {
+            if (!untokenizedCategory.getStoreType().equals(StoreType.RESTAURANT)) {
+                possibleCategories.add(untokenizedCategory.getStoreType().toString());
+                continue;
+            }
             String[] tokens = untokenizedCategory.getCategory().replace(SPACE, EMPTY).split(DELIMITER);
             for (String token : tokens) {
                 Optional<String> primaryCategory = StoreCategory.findPrimaryCategoryName(token);


### PR DESCRIPTION
## ✔️ 작업 내용
SearchService의 searchPossibleCategories 메서드에서 Store Type으로 구분하여 토큰화하도록 수정하려고 합니다.
 - RESTAURANT -> 카테고리 토큰화 하여 Set에 추가
 - CAFE, PCROOM, KARAOKE, BILLIARD -> Store Type 자체를 Set에 추가 

## 📋 요약
Store Type으로 구분하여 토큰화하도록 수정하여, 가능한 카테고리에 놀거리 항목이 나오지 않는 오류 해결

## 🔒 관련 이슈

close #76

## ➕ 기타 사항