### PR TITLE
공지 사항 및 건의 사항 정렬 조건 추가, 페이지네이션 적용, 검증 강화

### DIFF
--- a/src/main/java/wad/seoul_nolgoat/domain/inquiry/InquiryRepository.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/inquiry/InquiryRepository.java
@@ -2,6 +2,6 @@ package wad.seoul_nolgoat.domain.inquiry;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface InquiryRepository extends JpaRepository<Inquiry, Long> {
+public interface InquiryRepository extends JpaRepository<Inquiry, Long>, InquiryRepositoryCustom {
 
 }

--- a/src/main/java/wad/seoul_nolgoat/domain/inquiry/InquiryRepositoryCustom.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/inquiry/InquiryRepositoryCustom.java
@@ -1,0 +1,10 @@
+package wad.seoul_nolgoat.domain.inquiry;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import wad.seoul_nolgoat.web.inquiry.dto.response.InquiryListDto;
+
+public interface InquiryRepositoryCustom {
+
+    Page<InquiryListDto> findAllWithPagination(Pageable pageable);
+}

--- a/src/main/java/wad/seoul_nolgoat/domain/inquiry/InquiryRepositoryCustomImpl.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/inquiry/InquiryRepositoryCustomImpl.java
@@ -1,0 +1,49 @@
+package wad.seoul_nolgoat.domain.inquiry;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import wad.seoul_nolgoat.web.inquiry.dto.response.InquiryListDto;
+
+import java.util.List;
+
+import static wad.seoul_nolgoat.domain.inquiry.QInquiry.inquiry;
+
+@RequiredArgsConstructor
+public class InquiryRepositoryCustomImpl implements InquiryRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<InquiryListDto> findAllWithPagination(Pageable pageable) {
+
+        List<InquiryListDto> fetch = jpaQueryFactory
+                .select(
+                        Projections.constructor(
+                                InquiryListDto.class,
+                                inquiry.id,
+                                inquiry.title,
+                                inquiry.isPublic,
+                                inquiry.user.id,
+                                inquiry.user.nickname,
+                                inquiry.user.profileImage,
+                                inquiry.createdDate
+                        )
+                )
+                .from(inquiry)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(inquiry.createdDate.desc())
+                .fetch();
+
+        JPAQuery<Long> countQuery = jpaQueryFactory
+                .select(inquiry.count())
+                .from(inquiry);
+
+        return PageableExecutionUtils.getPage(fetch, pageable, countQuery::fetchOne);
+    }
+}

--- a/src/main/java/wad/seoul_nolgoat/domain/inquiry/InquiryRepositoryCustomImpl.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/inquiry/InquiryRepositoryCustomImpl.java
@@ -21,7 +21,7 @@ public class InquiryRepositoryCustomImpl implements InquiryRepositoryCustom {
     @Override
     public Page<InquiryListDto> findAllWithPagination(Pageable pageable) {
 
-        List<InquiryListDto> fetch = jpaQueryFactory
+        List<InquiryListDto> inquiries = jpaQueryFactory
                 .select(
                         Projections.constructor(
                                 InquiryListDto.class,
@@ -44,6 +44,6 @@ public class InquiryRepositoryCustomImpl implements InquiryRepositoryCustom {
                 .select(inquiry.count())
                 .from(inquiry);
 
-        return PageableExecutionUtils.getPage(fetch, pageable, countQuery::fetchOne);
+        return PageableExecutionUtils.getPage(inquiries, pageable, countQuery::fetchOne);
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/domain/notice/NoticeRepository.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/notice/NoticeRepository.java
@@ -2,6 +2,6 @@ package wad.seoul_nolgoat.domain.notice;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface NoticeRepository extends JpaRepository<Notice, Long> {
-    
+public interface NoticeRepository extends JpaRepository<Notice, Long>, NoticeRepositoryCustom {
+
 }

--- a/src/main/java/wad/seoul_nolgoat/domain/notice/NoticeRepositoryCustom.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/notice/NoticeRepositoryCustom.java
@@ -1,0 +1,10 @@
+package wad.seoul_nolgoat.domain.notice;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import wad.seoul_nolgoat.web.notice.dto.response.NoticeListDto;
+
+public interface NoticeRepositoryCustom {
+
+    Page<NoticeListDto> findAllWithPagination(Pageable pageable);
+}

--- a/src/main/java/wad/seoul_nolgoat/domain/notice/NoticeRepositoryCustomImpl.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/notice/NoticeRepositoryCustomImpl.java
@@ -1,0 +1,48 @@
+package wad.seoul_nolgoat.domain.notice;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import wad.seoul_nolgoat.web.notice.dto.response.NoticeListDto;
+
+import java.util.List;
+
+import static wad.seoul_nolgoat.domain.notice.QNotice.notice;
+
+@RequiredArgsConstructor
+public class NoticeRepositoryCustomImpl implements NoticeRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<NoticeListDto> findAllWithPagination(Pageable pageable) {
+        List<NoticeListDto> notices = jpaQueryFactory
+                .select(
+                        Projections.constructor(
+                                NoticeListDto.class,
+                                notice.id,
+                                notice.title,
+                                notice.views,
+                                notice.user.id,
+                                notice.user.nickname,
+                                notice.user.profileImage,
+                                notice.createdDate
+                        )
+                )
+                .from(notice)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(notice.createdDate.desc())
+                .fetch();
+
+        JPAQuery<Long> countQuery = jpaQueryFactory
+                .select(notice.count()) // select count(notice.id)
+                .from(notice);
+
+        return PageableExecutionUtils.getPage(notices, pageable, countQuery::fetchOne);
+    }
+}

--- a/src/main/java/wad/seoul_nolgoat/exception/ErrorCode.java
+++ b/src/main/java/wad/seoul_nolgoat/exception/ErrorCode.java
@@ -42,8 +42,9 @@ public enum ErrorCode {
     PARTY_NOT_HOST(HttpStatus.FORBIDDEN, "PARTY007", "파티 생성자만 참여자를 추방할 수 있습니다."),
     PARTY_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "PARTY008", "해당 파티에 참여하지 않은 유저입니다."),
 
-    // 문의 사항 관련
-    INQUIRY_NOT_FOUND(HttpStatus.NOT_FOUND, "INQUIRY001", "존재하지 않는 문의 사항입니다."),
+    // 건의 관련
+    INQUIRY_NOT_FOUND(HttpStatus.NOT_FOUND, "INQUIRY001", "존재하지 않는 건의 사항입니다."),
+    INQUIRY_WRITER_MISMATCH(HttpStatus.FORBIDDEN, "INQUIRY002", "건의 사항의 작성자가 아닙니다."),
 
     // 공지 관련
     NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTICE001", "존재하지 않는 공지입니다."),

--- a/src/main/java/wad/seoul_nolgoat/exception/ErrorCode.java
+++ b/src/main/java/wad/seoul_nolgoat/exception/ErrorCode.java
@@ -47,6 +47,7 @@ public enum ErrorCode {
 
     // 공지 관련
     NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTICE001", "존재하지 않는 공지입니다."),
+    NOTICE_WRITER_MISMATCH(HttpStatus.FORBIDDEN, "NOTICE002", "공지의 작성자가 아닙니다."),
 
     // 검색(필터링, 정렬) 관련
     INVALID_SEARCH_CRITERIA(HttpStatus.BAD_REQUEST, "SEARCH001", "유효하지 않은 검색 기준입니다."),

--- a/src/main/java/wad/seoul_nolgoat/service/inquiry/InquiryService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/inquiry/InquiryService.java
@@ -42,7 +42,7 @@ public class InquiryService {
         return InquiryMapper.toInquiryDetailsDto(inquiry);
     }
 
-    public Page<InquiryListDto> findAllInquiryWithPagination(Pageable pageable) {
+    public Page<InquiryListDto> findInquiriesWithPagination(Pageable pageable) {
         return inquiryRepository.findAllWithPagination(pageable);
     }
 

--- a/src/main/java/wad/seoul_nolgoat/service/inquiry/InquiryService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/inquiry/InquiryService.java
@@ -1,6 +1,8 @@
 package wad.seoul_nolgoat.service.inquiry;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import wad.seoul_nolgoat.domain.inquiry.Inquiry;
@@ -13,9 +15,6 @@ import wad.seoul_nolgoat.web.inquiry.dto.request.InquirySaveDto;
 import wad.seoul_nolgoat.web.inquiry.dto.request.InquiryUpdateDto;
 import wad.seoul_nolgoat.web.inquiry.dto.response.InquiryDetailsDto;
 import wad.seoul_nolgoat.web.inquiry.dto.response.InquiryListDto;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 import static wad.seoul_nolgoat.exception.ErrorCode.INQUIRY_NOT_FOUND;
 import static wad.seoul_nolgoat.exception.ErrorCode.USER_NOT_FOUND;
@@ -43,12 +42,8 @@ public class InquiryService {
         return InquiryMapper.toInquiryDetailsDto(inquiry);
     }
 
-    public List<InquiryListDto> findAllInquiry() {
-        List<Inquiry> inquiries = inquiryRepository.findAll();
-
-        return inquiries.stream()
-                .map(InquiryMapper::toInquiryListDto)
-                .collect(Collectors.toList());
+    public Page<InquiryListDto> findAllInquiryWithPagination(Pageable pageable) {
+        return inquiryRepository.findAllWithPagination(pageable);
     }
 
     @Transactional

--- a/src/main/java/wad/seoul_nolgoat/service/inquiry/InquiryService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/inquiry/InquiryService.java
@@ -16,8 +16,7 @@ import wad.seoul_nolgoat.web.inquiry.dto.request.InquiryUpdateDto;
 import wad.seoul_nolgoat.web.inquiry.dto.response.InquiryDetailsDto;
 import wad.seoul_nolgoat.web.inquiry.dto.response.InquiryListDto;
 
-import static wad.seoul_nolgoat.exception.ErrorCode.INQUIRY_NOT_FOUND;
-import static wad.seoul_nolgoat.exception.ErrorCode.USER_NOT_FOUND;
+import static wad.seoul_nolgoat.exception.ErrorCode.*;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -47,9 +46,18 @@ public class InquiryService {
     }
 
     @Transactional
-    public void update(Long inquiryId, InquiryUpdateDto inquiryUpdateDto) {
+    public void update(
+            String loginId,
+            Long inquiryId,
+            InquiryUpdateDto inquiryUpdateDto
+    ) {
         Inquiry inquiry = inquiryRepository.findById(inquiryId)
                 .orElseThrow(() -> new ApiException(INQUIRY_NOT_FOUND));
+
+        // 건의 작성자가 맞는지 검증
+        if (!loginId.equals(inquiry.getUser().getLoginId())) {
+            throw new ApiException(INQUIRY_WRITER_MISMATCH);
+        }
 
         inquiry.update(
                 inquiryUpdateDto.getTitle(),
@@ -59,11 +67,15 @@ public class InquiryService {
     }
 
     @Transactional
-    public void deleteById(Long inquiryId) {
-        if (!inquiryRepository.existsById(inquiryId)) {
-            throw new ApiException(INQUIRY_NOT_FOUND);
+    public void delete(String loginId, Long inquiryId) {
+        Inquiry inquiry = inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new ApiException(INQUIRY_NOT_FOUND));
+
+        // 건의 작성자가 맞는지 검증
+        if (!loginId.equals(inquiry.getUser().getLoginId())) {
+            throw new ApiException(INQUIRY_WRITER_MISMATCH);
         }
 
-        inquiryRepository.deleteById(inquiryId);
+        inquiryRepository.delete(inquiry);
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/service/notice/NoticeService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/notice/NoticeService.java
@@ -1,6 +1,8 @@
 package wad.seoul_nolgoat.service.notice;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import wad.seoul_nolgoat.domain.notice.Notice;
@@ -13,9 +15,6 @@ import wad.seoul_nolgoat.web.notice.dto.request.NoticeSaveDto;
 import wad.seoul_nolgoat.web.notice.dto.request.NoticeUpdateDto;
 import wad.seoul_nolgoat.web.notice.dto.response.NoticeDetailsDto;
 import wad.seoul_nolgoat.web.notice.dto.response.NoticeListDto;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 import static wad.seoul_nolgoat.exception.ErrorCode.NOTICE_NOT_FOUND;
 import static wad.seoul_nolgoat.exception.ErrorCode.USER_NOT_FOUND;
@@ -43,12 +42,8 @@ public class NoticeService {
         return NoticeMapper.toNoticeDetailsDto(notice);
     }
 
-    public List<NoticeListDto> findAllNotice() {
-        List<Notice> notices = noticeRepository.findAll();
-
-        return notices.stream()
-                .map(NoticeMapper::toNoticeListDto)
-                .collect(Collectors.toList());
+    public Page<NoticeListDto> findAllNoticeWithPagination(Pageable pageable) {
+        return noticeRepository.findAllWithPagination(pageable);
     }
 
     @Transactional

--- a/src/main/java/wad/seoul_nolgoat/service/notice/NoticeService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/notice/NoticeService.java
@@ -42,7 +42,7 @@ public class NoticeService {
         return NoticeMapper.toNoticeDetailsDto(notice);
     }
 
-    public Page<NoticeListDto> findAllNoticeWithPagination(Pageable pageable) {
+    public Page<NoticeListDto> findNoticesWithPagination(Pageable pageable) {
         return noticeRepository.findAllWithPagination(pageable);
     }
 

--- a/src/main/java/wad/seoul_nolgoat/service/notice/NoticeService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/notice/NoticeService.java
@@ -16,8 +16,7 @@ import wad.seoul_nolgoat.web.notice.dto.request.NoticeUpdateDto;
 import wad.seoul_nolgoat.web.notice.dto.response.NoticeDetailsDto;
 import wad.seoul_nolgoat.web.notice.dto.response.NoticeListDto;
 
-import static wad.seoul_nolgoat.exception.ErrorCode.NOTICE_NOT_FOUND;
-import static wad.seoul_nolgoat.exception.ErrorCode.USER_NOT_FOUND;
+import static wad.seoul_nolgoat.exception.ErrorCode.*;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -47,9 +46,18 @@ public class NoticeService {
     }
 
     @Transactional
-    public void update(Long noticeId, NoticeUpdateDto noticeUpdateDto) {
+    public void update(
+            String loginId,
+            Long noticeId,
+            NoticeUpdateDto noticeUpdateDto
+    ) {
         Notice notice = noticeRepository.findById(noticeId)
                 .orElseThrow(() -> new ApiException(NOTICE_NOT_FOUND));
+
+        // 공지 작성자가 맞는지 검증
+        if (!loginId.equals(notice.getUser().getLoginId())) {
+            throw new ApiException(NOTICE_WRITER_MISMATCH);
+        }
 
         notice.update(
                 noticeUpdateDto.getTitle(),
@@ -58,12 +66,16 @@ public class NoticeService {
     }
 
     @Transactional
-    public void deleteById(Long noticeId) {
-        if (!noticeRepository.existsById(noticeId)) {
-            throw new ApiException(NOTICE_NOT_FOUND);
+    public void delete(String loginId, Long noticeId) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new ApiException(NOTICE_NOT_FOUND));
+
+        // 공지 작성자가 맞는지 검증
+        if (!loginId.equals(notice.getUser().getLoginId())) {
+            throw new ApiException(NOTICE_WRITER_MISMATCH);
         }
 
-        noticeRepository.deleteById(noticeId);
+        noticeRepository.delete(notice);
     }
 
     @Transactional

--- a/src/main/java/wad/seoul_nolgoat/util/mapper/InquiryMapper.java
+++ b/src/main/java/wad/seoul_nolgoat/util/mapper/InquiryMapper.java
@@ -4,7 +4,6 @@ import wad.seoul_nolgoat.domain.inquiry.Inquiry;
 import wad.seoul_nolgoat.domain.user.User;
 import wad.seoul_nolgoat.web.inquiry.dto.request.InquirySaveDto;
 import wad.seoul_nolgoat.web.inquiry.dto.response.InquiryDetailsDto;
-import wad.seoul_nolgoat.web.inquiry.dto.response.InquiryListDto;
 
 import static wad.seoul_nolgoat.util.DateTimeUtil.formatDate;
 
@@ -24,18 +23,6 @@ public class InquiryMapper {
                 inquiry.getId(),
                 inquiry.getTitle(),
                 inquiry.getContent(),
-                inquiry.getIsPublic(),
-                inquiry.getUser().getId(),
-                inquiry.getUser().getNickname(),
-                inquiry.getUser().getProfileImage(),
-                formatDate(inquiry.getCreatedDate())
-        );
-    }
-
-    public static InquiryListDto toInquiryListDto(Inquiry inquiry) {
-        return new InquiryListDto(
-                inquiry.getId(),
-                inquiry.getTitle(),
                 inquiry.getIsPublic(),
                 inquiry.getUser().getId(),
                 inquiry.getUser().getNickname(),

--- a/src/main/java/wad/seoul_nolgoat/util/mapper/NoticeMapper.java
+++ b/src/main/java/wad/seoul_nolgoat/util/mapper/NoticeMapper.java
@@ -4,7 +4,6 @@ import wad.seoul_nolgoat.domain.notice.Notice;
 import wad.seoul_nolgoat.domain.user.User;
 import wad.seoul_nolgoat.web.notice.dto.request.NoticeSaveDto;
 import wad.seoul_nolgoat.web.notice.dto.response.NoticeDetailsDto;
-import wad.seoul_nolgoat.web.notice.dto.response.NoticeListDto;
 
 import static wad.seoul_nolgoat.util.DateTimeUtil.formatDate;
 
@@ -23,18 +22,6 @@ public class NoticeMapper {
                 notice.getId(),
                 notice.getTitle(),
                 notice.getContent(),
-                notice.getViews(),
-                notice.getUser().getId(),
-                notice.getUser().getNickname(),
-                notice.getUser().getProfileImage(),
-                formatDate(notice.getCreatedDate())
-        );
-    }
-
-    public static NoticeListDto toNoticeListDto(Notice notice) {
-        return new NoticeListDto(
-                notice.getId(),
-                notice.getTitle(),
                 notice.getViews(),
                 notice.getUser().getId(),
                 notice.getUser().getNickname(),

--- a/src/main/java/wad/seoul_nolgoat/web/inquiry/InquiryController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/inquiry/InquiryController.java
@@ -61,10 +61,15 @@ public class InquiryController {
     @Operation(summary = "건의 사항 수정")
     @PutMapping("/{inquiryId}")
     public ResponseEntity<Void> update(
+            @AuthenticationPrincipal OAuth2User loginUser,
             @PathVariable Long inquiryId,
             @Valid @RequestBody InquiryUpdateDto inquiryUpdateDto
     ) {
-        inquiryService.update(inquiryId, inquiryUpdateDto);
+        inquiryService.update(
+                loginUser.getName(),
+                inquiryId,
+                inquiryUpdateDto
+        );
 
         return ResponseEntity
                 .noContent()
@@ -73,8 +78,11 @@ public class InquiryController {
 
     @Operation(summary = "건의 사항 삭제")
     @DeleteMapping("/{inquiryId}")
-    public ResponseEntity<Void> deleteById(@PathVariable Long inquiryId) {
-        inquiryService.deleteById(inquiryId);
+    public ResponseEntity<Void> delete(
+            @AuthenticationPrincipal OAuth2User loginUser,
+            @PathVariable Long inquiryId
+    ) {
+        inquiryService.delete(loginUser.getName(), inquiryId);
 
         return ResponseEntity
                 .noContent()

--- a/src/main/java/wad/seoul_nolgoat/web/inquiry/InquiryController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/inquiry/InquiryController.java
@@ -3,6 +3,8 @@ package wad.seoul_nolgoat.web.inquiry;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -15,7 +17,6 @@ import wad.seoul_nolgoat.web.inquiry.dto.response.InquiryDetailsDto;
 import wad.seoul_nolgoat.web.inquiry.dto.response.InquiryListDto;
 
 import java.net.URI;
-import java.util.List;
 
 @Tag(name = "건의 사항")
 @RequiredArgsConstructor
@@ -49,11 +50,11 @@ public class InquiryController {
                 .ok(inquiryService.findByInquiryId(inquiryId));
     }
 
-    @Operation(summary = "건의 사항 목록 조회")
+    @Operation(summary = "건의 사항 목록 조회(페이지네이션)")
     @GetMapping
-    public ResponseEntity<List<InquiryListDto>> showAllInquiries() {
+    public ResponseEntity<Page<InquiryListDto>> showAllInquiries(Pageable pageable) {
         return ResponseEntity
-                .ok(inquiryService.findAllInquiry());
+                .ok(inquiryService.findAllInquiryWithPagination(pageable));
     }
 
     @Operation(summary = "건의 사항 수정")

--- a/src/main/java/wad/seoul_nolgoat/web/inquiry/InquiryController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/inquiry/InquiryController.java
@@ -2,6 +2,7 @@ package wad.seoul_nolgoat.web.inquiry;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -30,7 +31,7 @@ public class InquiryController {
     @PostMapping
     public ResponseEntity<Void> createInquiry(
             @AuthenticationPrincipal OAuth2User loginUser,
-            @RequestBody InquirySaveDto inquirySaveDto,
+            @Valid @RequestBody InquirySaveDto inquirySaveDto,
             UriComponentsBuilder uriComponentsBuilder
     ) {
         Long inquiryId = inquiryService.save(loginUser.getName(), inquirySaveDto);
@@ -61,7 +62,7 @@ public class InquiryController {
     @PutMapping("/{inquiryId}")
     public ResponseEntity<Void> update(
             @PathVariable Long inquiryId,
-            @RequestBody InquiryUpdateDto inquiryUpdateDto
+            @Valid @RequestBody InquiryUpdateDto inquiryUpdateDto
     ) {
         inquiryService.update(inquiryId, inquiryUpdateDto);
 

--- a/src/main/java/wad/seoul_nolgoat/web/inquiry/InquiryController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/inquiry/InquiryController.java
@@ -52,9 +52,9 @@ public class InquiryController {
 
     @Operation(summary = "건의 사항 목록 조회(페이지네이션)")
     @GetMapping
-    public ResponseEntity<Page<InquiryListDto>> showAllInquiries(Pageable pageable) {
+    public ResponseEntity<Page<InquiryListDto>> showInquiries(Pageable pageable) {
         return ResponseEntity
-                .ok(inquiryService.findAllInquiryWithPagination(pageable));
+                .ok(inquiryService.findInquiriesWithPagination(pageable));
     }
 
     @Operation(summary = "건의 사항 수정")

--- a/src/main/java/wad/seoul_nolgoat/web/inquiry/dto/request/InquirySaveDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/inquiry/dto/request/InquirySaveDto.java
@@ -1,5 +1,7 @@
 package wad.seoul_nolgoat.web.inquiry.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -7,7 +9,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class InquirySaveDto {
 
+    @NotBlank
+    @Size(max = 25, message = "제목은 25자 이내여야 합니다.")
     private final String title;
+
+    @NotBlank
+    @Size(max = 300, message = "내용은 300자 이내여야 합니다.")
     private final String content;
+
+    @NotBlank
     private final Boolean isPublic;
 }

--- a/src/main/java/wad/seoul_nolgoat/web/inquiry/dto/request/InquiryUpdateDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/inquiry/dto/request/InquiryUpdateDto.java
@@ -1,5 +1,7 @@
 package wad.seoul_nolgoat.web.inquiry.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -7,7 +9,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class InquiryUpdateDto {
 
+    @NotBlank
+    @Size(max = 25, message = "제목은 25자 이내여야 합니다.")
     private final String title;
+
+    @NotBlank
+    @Size(max = 300, message = "내용은 300자 이내여야 합니다.")
     private final String content;
+
+    @NotBlank
     private final Boolean isPublic;
 }

--- a/src/main/java/wad/seoul_nolgoat/web/inquiry/dto/response/InquiryListDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/inquiry/dto/response/InquiryListDto.java
@@ -19,7 +19,15 @@ public class InquiryListDto {
     private String userProfileImage;
     private String createDate;
 
-    public InquiryListDto(Long id, String title, Boolean isPublic, Long userId, String userNickname, String userProfileImage, LocalDateTime createDate) {
+    public InquiryListDto(
+            Long id,
+            String title,
+            Boolean isPublic,
+            Long userId,
+            String userNickname,
+            String userProfileImage,
+            LocalDateTime createDate
+    ) {
         this.id = id;
         this.title = title;
         this.isPublic = isPublic;

--- a/src/main/java/wad/seoul_nolgoat/web/inquiry/dto/response/InquiryListDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/inquiry/dto/response/InquiryListDto.java
@@ -1,17 +1,31 @@
 package wad.seoul_nolgoat.web.inquiry.dto.response;
 
+import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
+import wad.seoul_nolgoat.util.DateTimeUtil;
+
+import java.time.LocalDateTime;
 
 @Getter
-@RequiredArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class InquiryListDto {
 
-    private final Long id;
-    private final String title;
-    private final Boolean isPublic;
-    private final Long userId;
-    private final String userNickname;
-    private final String userProfileImage;
-    private final String createDate;
+    private Long id;
+    private String title;
+    private Boolean isPublic;
+    private Long userId;
+    private String userNickname;
+    private String userProfileImage;
+    private String createDate;
+
+    public InquiryListDto(Long id, String title, Boolean isPublic, Long userId, String userNickname, String userProfileImage, LocalDateTime createDate) {
+        this.id = id;
+        this.title = title;
+        this.isPublic = isPublic;
+        this.userId = userId;
+        this.userNickname = userNickname;
+        this.userProfileImage = userProfileImage;
+        this.createDate = DateTimeUtil.formatDate(createDate);
+    }
 }

--- a/src/main/java/wad/seoul_nolgoat/web/notice/NoticeController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/notice/NoticeController.java
@@ -53,9 +53,9 @@ public class NoticeController {
 
     @Operation(summary = "공지 사항 목록 조회(페이지네이션)")
     @GetMapping
-    public ResponseEntity<Page<NoticeListDto>> showAllNotices(Pageable pageable) {
+    public ResponseEntity<Page<NoticeListDto>> showNotices(Pageable pageable) {
         return ResponseEntity
-                .ok(noticeService.findAllNoticeWithPagination(pageable));
+                .ok(noticeService.findNoticesWithPagination(pageable));
     }
 
     @Operation(summary = "공지 사항 수정")

--- a/src/main/java/wad/seoul_nolgoat/web/notice/NoticeController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/notice/NoticeController.java
@@ -62,10 +62,15 @@ public class NoticeController {
     @Operation(summary = "공지 사항 수정")
     @PutMapping("/{noticeId}")
     public ResponseEntity<Void> update(
+            @AuthenticationPrincipal OAuth2User loginUser,
             @PathVariable Long noticeId,
             @Valid @RequestBody NoticeUpdateDto noticeUpdateDto
     ) {
-        noticeService.update(noticeId, noticeUpdateDto);
+        noticeService.update(
+                loginUser.getName(),
+                noticeId,
+                noticeUpdateDto
+        );
 
         return ResponseEntity
                 .noContent()
@@ -74,8 +79,11 @@ public class NoticeController {
 
     @Operation(summary = "공지 사항 삭제")
     @DeleteMapping("/{noticeId}")
-    public ResponseEntity<Void> deleteById(@PathVariable Long noticeId) {
-        noticeService.deleteById(noticeId);
+    public ResponseEntity<Void> delete(
+            @AuthenticationPrincipal OAuth2User loginUser,
+            @PathVariable Long noticeId
+    ) {
+        noticeService.delete(loginUser.getName(), noticeId);
 
         return ResponseEntity
                 .noContent()

--- a/src/main/java/wad/seoul_nolgoat/web/notice/NoticeController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/notice/NoticeController.java
@@ -3,6 +3,7 @@ package wad.seoul_nolgoat.web.notice;
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -31,7 +32,7 @@ public class NoticeController {
     @PostMapping
     public ResponseEntity<Void> createNotice(
             @AuthenticationPrincipal OAuth2User loginUser,
-            @RequestBody NoticeSaveDto noticeSaveDto,
+            @Valid @RequestBody NoticeSaveDto noticeSaveDto,
             UriComponentsBuilder uriComponentsBuilder
     ) {
         Long noticeId = noticeService.save(loginUser.getName(), noticeSaveDto);
@@ -62,7 +63,7 @@ public class NoticeController {
     @PutMapping("/{noticeId}")
     public ResponseEntity<Void> update(
             @PathVariable Long noticeId,
-            @RequestBody NoticeUpdateDto noticeUpdateDto
+            @Valid @RequestBody NoticeUpdateDto noticeUpdateDto
     ) {
         noticeService.update(noticeId, noticeUpdateDto);
 

--- a/src/main/java/wad/seoul_nolgoat/web/notice/NoticeController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/notice/NoticeController.java
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -16,7 +18,6 @@ import wad.seoul_nolgoat.web.notice.dto.response.NoticeDetailsDto;
 import wad.seoul_nolgoat.web.notice.dto.response.NoticeListDto;
 
 import java.net.URI;
-import java.util.List;
 
 @Tag(name = "공지 사항")
 @RequiredArgsConstructor
@@ -50,11 +51,11 @@ public class NoticeController {
                 .ok(noticeService.findByNoticeId(noticeId));
     }
 
-    @Operation(summary = "공지 사항 목록 조회")
+    @Operation(summary = "공지 사항 목록 조회(페이지네이션)")
     @GetMapping
-    public ResponseEntity<List<NoticeListDto>> showAllNotices() {
+    public ResponseEntity<Page<NoticeListDto>> showAllNotices(Pageable pageable) {
         return ResponseEntity
-                .ok(noticeService.findAllNotice());
+                .ok(noticeService.findAllNoticeWithPagination(pageable));
     }
 
     @Operation(summary = "공지 사항 수정")

--- a/src/main/java/wad/seoul_nolgoat/web/notice/dto/request/NoticeSaveDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/notice/dto/request/NoticeSaveDto.java
@@ -1,5 +1,7 @@
 package wad.seoul_nolgoat.web.notice.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -7,6 +9,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class NoticeSaveDto {
 
+    @NotBlank
+    @Size(max = 25, message = "제목은 25자 이내여야 합니다.")
     private final String title;
+
+    @NotBlank
+    @Size(max = 300, message = "내용은 300자 이내여야 합니다.")
     private final String content;
 }

--- a/src/main/java/wad/seoul_nolgoat/web/notice/dto/request/NoticeUpdateDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/notice/dto/request/NoticeUpdateDto.java
@@ -1,5 +1,7 @@
 package wad.seoul_nolgoat.web.notice.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -7,7 +9,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class NoticeUpdateDto {
 
+    @NotBlank
+    @Size(max = 25, message = "제목은 25자 이내여야 합니다.")
     private final String title;
+
+    @NotBlank
+    @Size(max = 300, message = "내용은 300자 이내여야 합니다.")
     private final String content;
-    private final Boolean isPublic;
 }

--- a/src/main/java/wad/seoul_nolgoat/web/notice/dto/response/NoticeListDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/notice/dto/response/NoticeListDto.java
@@ -1,18 +1,40 @@
 package wad.seoul_nolgoat.web.notice.dto.response;
 
+import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
+import wad.seoul_nolgoat.util.DateTimeUtil;
+
+import java.time.LocalDateTime;
 
 @Getter
-@RequiredArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NoticeListDto {
 
-    private final Long id;
-    private final String title;
-    private final int views;
-    private final Long userId;
-    private final String userNickname;
-    private final String userProfileImage;
-    private final String createDate;
+    private Long id;
+    private String title;
+    private int views;
+    private Long userId;
+    private String userNickname;
+    private String userProfileImage;
+    private String createDate;
+
+    public NoticeListDto(
+            Long id,
+            String title,
+            int views,
+            Long userId,
+            String userNickname,
+            String userProfileImage,
+            LocalDateTime createDate
+    ) {
+        this.id = id;
+        this.title = title;
+        this.views = views;
+        this.userId = userId;
+        this.userNickname = userNickname;
+        this.userProfileImage = userProfileImage;
+        this.createDate = DateTimeUtil.formatDate(createDate);
+    }
 }
 

--- a/src/test/java/wad/seoul_nolgoat/service/InquiryServiceTest.java
+++ b/src/test/java/wad/seoul_nolgoat/service/InquiryServiceTest.java
@@ -9,10 +9,14 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.test.context.ActiveProfiles;
+import wad.seoul_nolgoat.exception.ApiException;
 import wad.seoul_nolgoat.service.inquiry.InquiryService;
+import wad.seoul_nolgoat.web.inquiry.dto.request.InquiryUpdateDto;
 import wad.seoul_nolgoat.web.inquiry.dto.response.InquiryListDto;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static wad.seoul_nolgoat.exception.ErrorCode.INQUIRY_WRITER_MISMATCH;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -46,5 +50,32 @@ public class InquiryServiceTest {
 
         // 3페이지 검증
         assertThat(thirdPage.getContent().size()).isEqualTo(1);
+    }
+
+    @DisplayName("건의 사항 작성자가 아닌 사용자가 글을 수정하려 하면 예외가 발생합니다.")
+    @Test
+    void update_inquiry_when_non_creator_then_throw_exception() {
+        // given
+        String loginId = "user2";
+        Long inquiryId = 1L;
+        InquiryUpdateDto updateDto = new InquiryUpdateDto("변경된 제목", "변경된 내용", true);
+
+        // when // then
+        assertThatThrownBy(() -> inquiryService.update(loginId, inquiryId, updateDto))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(INQUIRY_WRITER_MISMATCH.getMessage());
+    }
+
+    @DisplayName("건의 사항 작성자가 아닌 사용자가 글을 삭제하려 하면 예외가 발생합니다.")
+    @Test
+    void delete_inquiry_when_non_creator_then_throw_exception() {
+        // given
+        String loginId = "user2";
+        Long inquiryId = 1L;
+
+        // when // then
+        assertThatThrownBy(() -> inquiryService.delete(loginId, inquiryId))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(INQUIRY_WRITER_MISMATCH.getMessage());
     }
 }

--- a/src/test/java/wad/seoul_nolgoat/service/InquiryServiceTest.java
+++ b/src/test/java/wad/seoul_nolgoat/service/InquiryServiceTest.java
@@ -1,0 +1,50 @@
+package wad.seoul_nolgoat.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.ActiveProfiles;
+import wad.seoul_nolgoat.service.inquiry.InquiryService;
+import wad.seoul_nolgoat.web.inquiry.dto.response.InquiryListDto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest
+public class InquiryServiceTest {
+
+    @Autowired
+    private InquiryService inquiryService;
+
+    @DisplayName("건의 사항 조회에 페이지네이션이 올바르게 적용되는지 확인합니다.")
+    @Test
+    void verify_inquiries_find_with_pagination() {
+        // given
+        Pageable firstPageable = PageRequest.of(0, 2, Sort.by(Sort.Direction.DESC, "createdDate"));
+        Pageable secondPageable = PageRequest.of(1, 2, Sort.by(Sort.Direction.DESC, "createdDate"));
+        Pageable thirdPageable = PageRequest.of(2, 2, Sort.by(Sort.Direction.DESC, "createdDate"));
+
+        // when
+        Page<InquiryListDto> firstPage = inquiryService.findInquiriesWithPagination(firstPageable);
+        Page<InquiryListDto> secondPage = inquiryService.findInquiriesWithPagination(secondPageable);
+        Page<InquiryListDto> thirdPage = inquiryService.findInquiriesWithPagination(thirdPageable);
+
+        // then
+        // 전체 페이지수 검증
+        assertThat(firstPage.getTotalPages()).isEqualTo(3);
+
+        // 1페이지 검증
+        assertThat(firstPage.getContent().size()).isEqualTo(2);
+
+        // 2페이지 검증
+        assertThat(secondPage.getContent().size()).isEqualTo(2);
+
+        // 3페이지 검증
+        assertThat(thirdPage.getContent().size()).isEqualTo(1);
+    }
+}

--- a/src/test/java/wad/seoul_nolgoat/service/NoticeServiceTest.java
+++ b/src/test/java/wad/seoul_nolgoat/service/NoticeServiceTest.java
@@ -9,10 +9,14 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.test.context.ActiveProfiles;
+import wad.seoul_nolgoat.exception.ApiException;
 import wad.seoul_nolgoat.service.notice.NoticeService;
+import wad.seoul_nolgoat.web.notice.dto.request.NoticeUpdateDto;
 import wad.seoul_nolgoat.web.notice.dto.response.NoticeListDto;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static wad.seoul_nolgoat.exception.ErrorCode.NOTICE_WRITER_MISMATCH;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -46,5 +50,32 @@ public class NoticeServiceTest {
 
         // 3페이지 검증
         assertThat(thirdPage.getContent().size()).isEqualTo(1);
+    }
+
+    @DisplayName("공지 사항 작성자가 아닌 사용자가 글을 수정하려 하면 예외가 발생합니다.")
+    @Test
+    void update_notice_when_non_creator_then_throw_exception() {
+        // given
+        String loginId = "user2";
+        Long noticeId = 1L;
+        NoticeUpdateDto updateDto = new NoticeUpdateDto("변경된 제목", "변경된 내용");
+
+        // when // then
+        assertThatThrownBy(() -> noticeService.update(loginId, noticeId, updateDto))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(NOTICE_WRITER_MISMATCH.getMessage());
+    }
+
+    @DisplayName("공지 사항 작성자가 아닌 사용자가 글을 삭제하려 하면 예외가 발생합니다.")
+    @Test
+    void delete_notice_when_non_creator_then_throw_exception() {
+        // given
+        String loginId = "user2";
+        Long noticeId = 1L;
+
+        // when // then
+        assertThatThrownBy(() -> noticeService.delete(loginId, noticeId))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(NOTICE_WRITER_MISMATCH.getMessage());
     }
 }

--- a/src/test/java/wad/seoul_nolgoat/service/NoticeServiceTest.java
+++ b/src/test/java/wad/seoul_nolgoat/service/NoticeServiceTest.java
@@ -1,0 +1,50 @@
+package wad.seoul_nolgoat.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.ActiveProfiles;
+import wad.seoul_nolgoat.service.notice.NoticeService;
+import wad.seoul_nolgoat.web.notice.dto.response.NoticeListDto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest
+public class NoticeServiceTest {
+
+    @Autowired
+    private NoticeService noticeService;
+
+    @DisplayName("공지 사항 조회에 페이지네이션이 올바르게 적용되는지 확인합니다.")
+    @Test
+    void verify_notices_find_with_pagination() {
+        // given
+        Pageable firstPageable = PageRequest.of(0, 2, Sort.by(Sort.Direction.DESC, "createdDate"));
+        Pageable secondPageable = PageRequest.of(1, 2, Sort.by(Sort.Direction.DESC, "createdDate"));
+        Pageable thirdPageable = PageRequest.of(2, 2, Sort.by(Sort.Direction.DESC, "createdDate"));
+
+        // when
+        Page<NoticeListDto> firstPage = noticeService.findNoticesWithPagination(firstPageable);
+        Page<NoticeListDto> secondPage = noticeService.findNoticesWithPagination(secondPageable);
+        Page<NoticeListDto> thirdPage = noticeService.findNoticesWithPagination(thirdPageable);
+
+        // then
+        // 전체 페이지수 검증
+        assertThat(firstPage.getTotalPages()).isEqualTo(3);
+
+        // 1페이지 검증
+        assertThat(firstPage.getContent().size()).isEqualTo(2);
+
+        // 2페이지 검증
+        assertThat(secondPage.getContent().size()).isEqualTo(2);
+
+        // 3페이지 검증
+        assertThat(thirdPage.getContent().size()).isEqualTo(1);
+    }
+}

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -37,3 +37,17 @@ VALUES ('PartyA', 'Party Content A', null, 6, '2024-12-31T23:59:59', false, fals
        ('PartyC', 'Party Content C', null, 4, '2024-11-30T12:00:00', false, false, 3),
        ('PartyD', 'Party Content D', null, 4, '2024-11-11T11:11:11', true, false, 1),
        ('PartyE', 'Party Content E', null, 4, '2024-12-12T12:12:12', true, true, 4);
+
+INSERT INTO inquiry (user_id, title, content, is_public, created_date, last_modified_date)
+VALUES (1, 'InquiryA', 'ContentA', true, '2024-12-01T10:00:00', '2024-12-01T10:10:00'),
+       (2, 'InquiryB', 'ContentB', false, '2024-12-02T11:00:00', '2024-12-02T11:10:00'),
+       (3, 'InquiryC', 'ContentC', true, '2024-12-03T12:00:00', '2024-12-03T12:10:00'),
+       (1, 'InquiryD', 'ContentD', false, '2024-12-04T13:00:00', '2024-12-04T13:10:00'),
+       (4, 'InquiryE', 'ContentE', true, '2024-12-05T14:00:00', '2024-12-05T14:10:00');
+
+INSERT INTO notice (user_id, title, content, views, created_date, last_modified_date)
+VALUES (1, 'noticeA', 'ContentA', 0, '2024-12-01T10:00:00', '2024-12-01T10:10:00'),
+       (2, 'noticeB', 'ContentB', 0, '2024-12-02T11:00:00', '2024-12-02T11:10:00'),
+       (3, 'noticeC', 'ContentC', 0, '2024-12-03T12:00:00', '2024-12-03T12:10:00'),
+       (1, 'noticeD', 'ContentD', 0, '2024-12-04T13:00:00', '2024-12-04T13:10:00'),
+       (4, 'noticeE', 'ContentE', 0, '2024-12-05T14:00:00', '2024-12-05T14:10:00');


### PR DESCRIPTION
## ✔️ 작업 내용

- **NoticeRepositoryCustomImpl, InquiryRepositoryCustomImpl**
  - 목록 조회에 `페이지네이션`을 적용했습니다.
  - 반환 타입을 `Page<T>`로 설정하고 메서드 인자에 `Pageable`을 추가했습니다.
- **NoticeService, InquiryService**
  - 글 수정 및 삭제 시, 작성자가 맞는지 검증하는 로직을 추가했습니다.
- **NoticeController, InquiryController**
  - 저장 및 수정 `DTO`에 `Bean Validation`을 적용했습니다.
  - `페이지네이션` 적용을 위해 `Pageable`을 요청 데이터로 받습니다.

## 📋 요약

- 공지 사항 및 건의 사항 `페이지네이션` 적용
- 제목(`25자 이하`), 내용(`300자 이하`) `Bean Validation` 적용
- 글 수정 및 삭제 시, 작성자가 맞는지 검증

## 🔒 관련 이슈

close #66

## ➕ 기타 사항