### PR TITLE
Store 관련 로직의 전반적인 개선

### DIFF
--- a/src/main/java/wad/seoul_nolgoat/domain/store/Store.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/store/Store.java
@@ -94,20 +94,28 @@ public class Store extends BaseTimeEntity {
         this.kakaoAverageGrade = kakaoAverageGrade;
     }
 
-    // 처음 리뷰를 작성할 때, 해당 평점을 기존 평균 평점에 반영
+    // 처음 리뷰를 작성할 때, 해당 Nolgoat 평점을 기존 Nolgoat 평균 평점에 반영
     public void addNolgoatGrade(int addedNolgoatGrade) {
-        double previousAverageGrade = this.nolgoatAverageGrade;
+        double previousNolgoatAverageGrade = this.nolgoatAverageGrade;
         int reviewCount = reviews.size();
 
-        this.nolgoatAverageGrade = ((previousAverageGrade * reviewCount) + addedNolgoatGrade) / (reviewCount + 1);
+        this.nolgoatAverageGrade = ((previousNolgoatAverageGrade * reviewCount) + addedNolgoatGrade) / (reviewCount + 1);
     }
 
-    // 리뷰를 수정할 때, 기존 평균 평점을 업데이트
-    public void updateNolgoatAverageGrade(int gradeDifference) {
-        double previousAverageGrade = this.nolgoatAverageGrade;
+    // 리뷰를 수정할 때, 기존 Nolgoat 평균 평점을 업데이트
+    public void updateNolgoatAverageGradeForEditReview(int nolgoatGradeDifference) {
+        double previousNolgoatAverageGrade = this.nolgoatAverageGrade;
         int reviewCount = reviews.size();
 
-        this.nolgoatAverageGrade = ((previousAverageGrade * reviewCount) + gradeDifference) / reviewCount;
+        this.nolgoatAverageGrade = ((previousNolgoatAverageGrade * reviewCount) + nolgoatGradeDifference) / reviewCount;
+    }
+
+    // 리뷰를 삭제할 때, 기존 Nolgoat 평균 평점을 업데이트
+    public void updateNolgoatAverageGradeForDeleteReview(int nolgoatGrade) {
+        double previousNolgoatAverageGrade = this.nolgoatAverageGrade;
+        int reviewCount = reviews.size();
+
+        this.nolgoatAverageGrade = ((previousNolgoatAverageGrade * reviewCount) - nolgoatGrade) / (reviewCount - 1);
     }
 
     public void delete() {

--- a/src/main/java/wad/seoul_nolgoat/domain/store/Store.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/store/Store.java
@@ -102,6 +102,14 @@ public class Store extends BaseTimeEntity {
         this.nolgoatAverageGrade = ((previousAverageGrade * reviewCount) + addedNolgoatGrade) / (reviewCount + 1);
     }
 
+    // 리뷰를 수정할 때, 기존 평균 평점을 업데이트
+    public void updateNolgoatAverageGrade(int gradeDifference) {
+        double previousAverageGrade = this.nolgoatAverageGrade;
+        int reviewCount = reviews.size();
+
+        this.nolgoatAverageGrade = ((previousAverageGrade * reviewCount) + gradeDifference) / reviewCount;
+    }
+
     public void delete() {
         this.isDeleted = true;
     }

--- a/src/main/java/wad/seoul_nolgoat/domain/store/Store.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/store/Store.java
@@ -94,6 +94,14 @@ public class Store extends BaseTimeEntity {
         this.kakaoAverageGrade = kakaoAverageGrade;
     }
 
+    // 처음 리뷰를 작성할 때, 해당 평점을 기존 평균 평점에 반영
+    public void addNolgoatGrade(int addedNolgoatGrade) {
+        double previousAverageGrade = this.nolgoatAverageGrade;
+        int reviewCount = reviews.size();
+
+        this.nolgoatAverageGrade = ((previousAverageGrade * reviewCount) + addedNolgoatGrade) / (reviewCount + 1);
+    }
+
     public void delete() {
         this.isDeleted = true;
     }

--- a/src/main/java/wad/seoul_nolgoat/domain/store/Store.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/store/Store.java
@@ -37,7 +37,7 @@ public class Store extends BaseTimeEntity {
     private String placeUrl;
     private Boolean isDeleted;
 
-    @OneToMany(mappedBy = "store", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "store")
     private List<Review> reviews = new ArrayList<>();
 
     public Store(

--- a/src/main/java/wad/seoul_nolgoat/domain/store/StoreRepository.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/store/StoreRepository.java
@@ -1,13 +1,7 @@
 package wad.seoul_nolgoat.domain.store;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface StoreRepository extends JpaRepository<Store, Long>, StoreRepositoryCustom {
 
-    @Modifying
-    @Query("UPDATE Store s SET s.nolgoatAverageGrade = :nolgoatAverageGrade WHERE s.id = :storeId")
-    void updateNolgoatAverageGrade(@Param("storeId") Long storeId, @Param("nolgoatAverageGrade") double nolgoatAverageGrade);
 }

--- a/src/main/java/wad/seoul_nolgoat/domain/store/StoreRepositoryCustom.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/store/StoreRepositoryCustom.java
@@ -4,10 +4,14 @@ import wad.seoul_nolgoat.service.search.dto.StoreForDistanceSortDto;
 import wad.seoul_nolgoat.service.search.dto.StoreForGradeSortDto;
 import wad.seoul_nolgoat.service.search.dto.StoreForPossibleCategoriesDto;
 import wad.seoul_nolgoat.web.search.dto.CoordinateDto;
+import wad.seoul_nolgoat.web.store.dto.response.StoreDetailsDto;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface StoreRepositoryCustom {
+
+    Optional<StoreDetailsDto> findStoreWithReviewsByStoreId(Long storeId);
 
     List<StoreForDistanceSortDto> findByRadiusRangeAndCategoryForDistanceSort(
             CoordinateDto startCoordinate,

--- a/src/main/java/wad/seoul_nolgoat/domain/user/UserRepository.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/user/UserRepository.java
@@ -6,7 +6,5 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    boolean existsByLoginId(String LoginId);
-
     Optional<User> findByLoginId(String LoginId);
 }

--- a/src/main/java/wad/seoul_nolgoat/service/bookmark/BookmarkService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/bookmark/BookmarkService.java
@@ -59,15 +59,15 @@ public class BookmarkService {
         bookmarkRepository.delete(bookmark);
     }
 
-    public boolean checkIfBookmarked(Long userId, Long storeId) {
-        return bookmarkRepository.existsByUserIdAndStoreId(userId, storeId);
-    }
-
     public List<StoreForBookmarkDto> findBookmarkedStoresByUserId(Long userId) {
         List<Bookmark> bookmarks = bookmarkRepository.findByUserId(userId);
 
         return bookmarks.stream()
                 .map(bookmark -> StoreMapper.toStoreForBookmarkDto(bookmark.getStore()))
                 .toList();
+    }
+
+    public boolean checkIfBookmarked(Long userId, Long storeId) {
+        return bookmarkRepository.existsByUserIdAndStoreId(userId, storeId);
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/service/review/ReviewService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/review/ReviewService.java
@@ -79,8 +79,16 @@ public class ReviewService {
     public void update(Long reviewId, ReviewUpdateDto reviewUpdateDto) {
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new ApiException(REVIEW_NOT_FOUND));
+
+        int previousGrade = review.getGrade();
+        int currentGrade = reviewUpdateDto.getGrade();
+        int gradeDifference = previousGrade - currentGrade;
+
+        Store store = review.getStore();
+        store.updateNolgoatAverageGrade(gradeDifference);
+
         review.update(
-                reviewUpdateDto.getGrade(),
+                currentGrade,
                 reviewUpdateDto.getContent()
         );
     }

--- a/src/main/java/wad/seoul_nolgoat/service/review/ReviewService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/review/ReviewService.java
@@ -44,6 +44,9 @@ public class ReviewService {
         User user = userRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new ApiException(USER_NOT_FOUND));
 
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new ApiException(STORE_NOT_FOUND));
+
         if (reviewRepository.existsByUserIdAndStoreId(user.getId(), storeId)) {
             throw new ApiException(DUPLICATE_REVIEW);
         }
@@ -52,10 +55,7 @@ public class ReviewService {
                 .filter(file -> !file.isEmpty())
                 .map(s3Service::saveFile);
 
-        storeService.updateAverageGradeOnReviewAdd(storeId, reviewSaveDto.getGrade());
-
-        Store store = storeRepository.findById(storeId)
-                .orElseThrow(() -> new ApiException(STORE_NOT_FOUND));
+        store.addNolgoatGrade(reviewSaveDto.getGrade());
 
         return reviewRepository.save(
                 ReviewMapper.toEntity(

--- a/src/main/java/wad/seoul_nolgoat/service/store/StoreService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/store/StoreService.java
@@ -7,7 +7,6 @@ import wad.seoul_nolgoat.domain.store.Store;
 import wad.seoul_nolgoat.domain.store.StoreRepository;
 import wad.seoul_nolgoat.exception.ApiException;
 import wad.seoul_nolgoat.service.store.dto.StoreUpdateDto;
-import wad.seoul_nolgoat.util.mapper.StoreMapper;
 import wad.seoul_nolgoat.web.store.dto.response.StoreDetailsDto;
 
 import static wad.seoul_nolgoat.exception.ErrorCode.STORE_NOT_FOUND;
@@ -19,11 +18,9 @@ public class StoreService {
 
     private final StoreRepository storeRepository;
 
-    public StoreDetailsDto findByStoreId(Long storeId) {
-        Store store = storeRepository.findById(storeId)
+    public StoreDetailsDto findStoreWithReviewsByStoreId(Long storeId) {
+        return storeRepository.findStoreWithReviewsByStoreId(storeId)
                 .orElseThrow(() -> new ApiException(STORE_NOT_FOUND));
-
-        return StoreMapper.toStoreDetailsDto(store);
     }
 
     @Transactional

--- a/src/main/java/wad/seoul_nolgoat/service/store/StoreService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/store/StoreService.java
@@ -40,42 +40,4 @@ public class StoreService {
                 storeUpdateDto.getPlaceUrl()
         );
     }
-
-    // Review 추가시 Store averageGrade 업데이트
-    @Transactional
-    public void updateAverageGradeOnReviewAdd(Long storeId, double addedGrade) {
-        Store store = storeRepository.findById(storeId).get();
-        double previousAverageGrade = store.getNolgoatAverageGrade();
-        int reviewCount = store.getReviews().size();
-
-        double updatedAverageGrade = (previousAverageGrade * reviewCount + addedGrade) / (reviewCount + 1);
-        storeRepository.updateNolgoatAverageGrade(storeId, updatedAverageGrade);
-    }
-
-    // Review 업데이트시 Store averageGrade 업데이트
-    @Transactional
-    public void updateAverageGradeOnReviewUpdate(Long storeId, double gradeDifference) {
-        Store store = storeRepository.findById(storeId).get();
-        double previousAverageGrade = store.getNolgoatAverageGrade();
-        int reviewCount = store.getReviews().size();
-
-        double updatedAverageGrade = (previousAverageGrade * reviewCount + gradeDifference) / reviewCount;
-        storeRepository.updateNolgoatAverageGrade(storeId, updatedAverageGrade);
-    }
-
-    // Review 삭제시 Store averageGrade 업데이트
-    @Transactional
-    public void updateAverageGradeOnReviewDelete(Long storeId, double deletedGrade) {
-        Store store = storeRepository.findById(storeId).get();
-        double previousAverageGrade = store.getNolgoatAverageGrade();
-        int reviewCount = store.getReviews().size();
-
-        if (reviewCount == 1) {
-            storeRepository.updateNolgoatAverageGrade(storeId, 0);
-            return;
-        }
-
-        double updatedAverageGrade = (previousAverageGrade * reviewCount - deletedGrade) / (reviewCount - 1);
-        storeRepository.updateNolgoatAverageGrade(storeId, updatedAverageGrade);
-    }
 }

--- a/src/main/java/wad/seoul_nolgoat/service/store/StoreService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/store/StoreService.java
@@ -41,14 +41,7 @@ public class StoreService {
         );
     }
 
-    @Transactional
-    public void deleteById(Long storeId) {
-        Store store = storeRepository.findById(storeId)
-                .orElseThrow(() -> new ApiException(STORE_NOT_FOUND));
-        store.delete();
-    }
-
-    // Review 추가시 Accommodation averageGrade 업데이트
+    // Review 추가시 Store averageGrade 업데이트
     @Transactional
     public void updateAverageGradeOnReviewAdd(Long storeId, double addedGrade) {
         Store store = storeRepository.findById(storeId).get();
@@ -59,7 +52,7 @@ public class StoreService {
         storeRepository.updateNolgoatAverageGrade(storeId, updatedAverageGrade);
     }
 
-    // Review 업데이트시 Accommodation averageGrade 업데이트
+    // Review 업데이트시 Store averageGrade 업데이트
     @Transactional
     public void updateAverageGradeOnReviewUpdate(Long storeId, double gradeDifference) {
         Store store = storeRepository.findById(storeId).get();
@@ -70,7 +63,7 @@ public class StoreService {
         storeRepository.updateNolgoatAverageGrade(storeId, updatedAverageGrade);
     }
 
-    // Review 삭제시 Accommodation averageGrade 업데이트
+    // Review 삭제시 Store averageGrade 업데이트
     @Transactional
     public void updateAverageGradeOnReviewDelete(Long storeId, double deletedGrade) {
         Store store = storeRepository.findById(storeId).get();

--- a/src/main/java/wad/seoul_nolgoat/util/mapper/StoreMapper.java
+++ b/src/main/java/wad/seoul_nolgoat/util/mapper/StoreMapper.java
@@ -1,5 +1,6 @@
 package wad.seoul_nolgoat.util.mapper;
 
+import wad.seoul_nolgoat.domain.review.Review;
 import wad.seoul_nolgoat.domain.store.Store;
 import wad.seoul_nolgoat.service.search.dto.StoreForDistanceSortDto;
 import wad.seoul_nolgoat.service.search.dto.StoreForGradeSortDto;
@@ -7,9 +8,12 @@ import wad.seoul_nolgoat.web.store.dto.response.StoreDetailsDto;
 import wad.seoul_nolgoat.web.store.dto.response.StoreForBookmarkDto;
 import wad.seoul_nolgoat.web.store.dto.response.StoreForCombinationDto;
 
+import java.util.List;
+import java.util.Objects;
+
 public class StoreMapper {
 
-    public static StoreDetailsDto toStoreDetailsDto(Store store) {
+    public static StoreDetailsDto toStoreDetailsDto(Store store, List<Review> reviews) {
         return new StoreDetailsDto(
                 store.getId(),
                 store.getStoreType(),
@@ -24,7 +28,8 @@ public class StoreMapper {
                 store.getKakaoAverageGrade(),
                 store.getNolgoatAverageGrade(),
                 store.getPlaceUrl(),
-                store.getReviews().stream()
+                reviews.stream()
+                        .filter(Objects::nonNull) // review가 존재할 때만 적용
                         .map(ReviewMapper::toReviewDetailsForStoreDto)
                         .toList()
         );

--- a/src/main/java/wad/seoul_nolgoat/web/review/ReviewController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/review/ReviewController.java
@@ -14,10 +14,8 @@ import org.springframework.web.util.UriComponentsBuilder;
 import wad.seoul_nolgoat.service.review.ReviewService;
 import wad.seoul_nolgoat.web.review.dto.request.ReviewSaveDto;
 import wad.seoul_nolgoat.web.review.dto.request.ReviewUpdateDto;
-import wad.seoul_nolgoat.web.review.dto.response.ReviewDetailsForUserDto;
 
 import java.net.URI;
-import java.util.List;
 
 @Tag(name = "리뷰")
 @RequiredArgsConstructor
@@ -49,13 +47,6 @@ public class ReviewController {
         return ResponseEntity
                 .created(location)
                 .build();
-    }
-
-    @Operation(summary = "유저 ID를 통한 리뷰 목록 조회")
-    @GetMapping("/{userId}")
-    public ResponseEntity<List<ReviewDetailsForUserDto>> showReviewsByUserId(@PathVariable Long userId) {
-        return ResponseEntity
-                .ok(reviewService.findByUserId(userId));
     }
 
     @Hidden

--- a/src/main/java/wad/seoul_nolgoat/web/store/StoreController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/store/StoreController.java
@@ -8,12 +8,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import wad.seoul_nolgoat.service.bookmark.BookmarkService;
 import wad.seoul_nolgoat.service.store.StoreService;
 import wad.seoul_nolgoat.web.store.dto.response.StoreDetailsDto;
-import wad.seoul_nolgoat.web.store.dto.response.StoreForBookmarkDto;
-
-import java.util.List;
 
 @Tag(name = "가게")
 @RequiredArgsConstructor
@@ -22,19 +18,11 @@ import java.util.List;
 public class StoreController {
 
     private final StoreService storeService;
-    private final BookmarkService bookmarkService;
 
     @Operation(summary = "가게 단건 조회")
     @GetMapping("/{storeId}")
     public ResponseEntity<StoreDetailsDto> showStoreByStoreId(@PathVariable Long storeId) {
         return ResponseEntity
                 .ok(storeService.findStoreWithReviewsByStoreId(storeId));
-    }
-
-    @Operation(summary = "유저 ID를 통한 즐겨찾기 가게 목록 조회")
-    @GetMapping("/bookmarked/{userId}")
-    public ResponseEntity<List<StoreForBookmarkDto>> showBookmarkedStoresByUserId(@PathVariable Long userId) {
-        return ResponseEntity
-                .ok(bookmarkService.findBookmarkedStoresByUserId(userId));
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/web/store/StoreController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/store/StoreController.java
@@ -28,7 +28,7 @@ public class StoreController {
     @GetMapping("/{storeId}")
     public ResponseEntity<StoreDetailsDto> showStoreByStoreId(@PathVariable Long storeId) {
         return ResponseEntity
-                .ok(storeService.findByStoreId(storeId));
+                .ok(storeService.findStoreWithReviewsByStoreId(storeId));
     }
 
     @Operation(summary = "유저 ID를 통한 즐겨찾기 가게 목록 조회")

--- a/src/main/java/wad/seoul_nolgoat/web/user/UserController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/user/UserController.java
@@ -9,12 +9,17 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
+import wad.seoul_nolgoat.service.bookmark.BookmarkService;
+import wad.seoul_nolgoat.service.review.ReviewService;
 import wad.seoul_nolgoat.service.user.UserService;
+import wad.seoul_nolgoat.web.review.dto.response.ReviewDetailsForUserDto;
+import wad.seoul_nolgoat.web.store.dto.response.StoreForBookmarkDto;
 import wad.seoul_nolgoat.web.user.dto.request.UserSaveDto;
 import wad.seoul_nolgoat.web.user.dto.request.UserUpdateDto;
 import wad.seoul_nolgoat.web.user.dto.response.UserProfileDto;
 
 import java.net.URI;
+import java.util.List;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/users")
@@ -22,6 +27,8 @@ import java.net.URI;
 public class UserController {
 
     private final UserService userService;
+    private final BookmarkService bookmarkService;
+    private final ReviewService reviewService;
 
     @Hidden
     @PostMapping
@@ -58,5 +65,19 @@ public class UserController {
         return ResponseEntity
                 .noContent()
                 .build();
+    }
+
+    @Operation(summary = "유저 ID를 통한 즐겨찾기 가게 목록 조회")
+    @GetMapping("/{userId}/bookmarks")
+    public ResponseEntity<List<StoreForBookmarkDto>> showBookmarkedStoresByUserId(@PathVariable Long userId) {
+        return ResponseEntity
+                .ok(bookmarkService.findBookmarkedStoresByUserId(userId));
+    }
+
+    @Operation(summary = "유저 ID를 통한 리뷰 목록 조회")
+    @GetMapping("/{userId}/reviews")
+    public ResponseEntity<List<ReviewDetailsForUserDto>> showReviewsByUserId(@PathVariable Long userId) {
+        return ResponseEntity
+                .ok(reviewService.findByUserId(userId));
     }
 }


### PR DESCRIPTION
## ✔️ 작업 내용

- **가게 단건 조회**
  - `가게`, `리뷰`, `유저` 정보를 하나의 쿼리로 조회할 수 있도록 조인 로직을 개선했습니다.
- **리뷰의 평점 반영 로직 개선**
  - 리뷰 `작성`, `수정`, `삭제` 시, 가게의 평균 평점에 반영하는 로직에서 불필요한 쿼리를 없앴습니다.
- **UserController 엔드포인트 수정**
  - `UserId`를 통해 `리뷰` 및 `북마크` 목록을 가져오는 로직을 `유저` 도메인에 맞게 변경했습니다.

## 📋 요약

- 가게 단건 조회 시, 하나의 쿼리만 실행되도록 수정
- 리뷰 `작성`, `수정`, `삭제` 시, 가게 평균 평점 반영 로직 개선 (불필요한 쿼리 제거)
- `User` 도메인에 맞는 엔드포인트 구조로 변경

## 🔒 관련 이슈

close #85

## ➕ 기타 사항