### PR TITLE
파티 기능 보완

### DIFF
--- a/src/main/java/wad/seoul_nolgoat/domain/party/AdministrativeDistrict.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/party/AdministrativeDistrict.java
@@ -1,0 +1,40 @@
+package wad.seoul_nolgoat.domain.party;
+
+public enum AdministrativeDistrict {
+
+    GANGNAM_GU("강남구"),
+    GANGDONG_GU("강동구"),
+    GANGSEO_GU("강서구"),
+    GANGBUK_GU("강북구"),
+    GWANAK_GU("관악구"),
+    GWANGJIN_GU("광진구"),
+    GURO_GU("구로구"),
+    GEUMCHEON_GU("금천구"),
+    NOWON_GU("노원구"),
+    DOBONG_GU("도봉구"),
+    DONGDAEMUN_GU("동대문구"),
+    DONGJAK_GU("동작구"),
+    MAPO_GU("마포구"),
+    SEODAEMUN_GU("서대문구"),
+    SEOCHO_GU("서초구"),
+    SEONGDONG_GU("성동구"),
+    SEONGBUK_GU("성북구"),
+    SONGPA_GU("송파구"),
+    YANGCHEON_GU("양천구"),
+    YEONGDEUNGPO_GU("영등포구"),
+    YONGSAN_GU("용산구"),
+    EUNPYEONG_GU("은평구"),
+    JONGNO_GU("종로구"),
+    JUNG_GU("중구"),
+    JUNGNANG_GU("중랑구");
+
+    private final String displayName;
+
+    AdministrativeDistrict(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/src/main/java/wad/seoul_nolgoat/domain/party/Party.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/party/Party.java
@@ -26,11 +26,8 @@ public class Party extends BaseTimeEntity {
     private boolean isClosed;
     private boolean isDeleted;
 
-    // 지역 추가 예정
-    // private Enum? location;
-
-    // 상점을 연관관계 대신 문자(상점 링크)로 추가
-    // 필터링을 위해서 카테고리는 있어야 할 거 같음
+    @Enumerated(EnumType.STRING)
+    private AdministrativeDistrict administrativeDistrict;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private User host;
@@ -41,6 +38,7 @@ public class Party extends BaseTimeEntity {
             String imageUrl,
             int maxCapacity,
             LocalDateTime deadline,
+            String district,
             User host
     ) {
         this.title = title;
@@ -50,6 +48,7 @@ public class Party extends BaseTimeEntity {
         this.deadline = deadline;
         this.isClosed = false;
         this.isDeleted = false;
+        this.administrativeDistrict = AdministrativeDistrict.valueOf(district);
         this.host = host;
     }
 

--- a/src/main/java/wad/seoul_nolgoat/domain/party/Party.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/party/Party.java
@@ -59,4 +59,8 @@ public class Party extends BaseTimeEntity {
     public void delete() {
         isDeleted = true;
     }
+
+    public boolean hasImageUrl() {
+        return this.imageUrl != null && !this.imageUrl.isEmpty();
+    }
 }

--- a/src/main/java/wad/seoul_nolgoat/domain/party/Party.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/party/Party.java
@@ -6,13 +6,19 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import wad.seoul_nolgoat.domain.BaseTimeEntity;
 import wad.seoul_nolgoat.domain.user.User;
+import wad.seoul_nolgoat.exception.ApiException;
 
 import java.time.LocalDateTime;
+
+import static wad.seoul_nolgoat.exception.ErrorCode.PARTY_CAPACITY_EXCEEDED;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Party extends BaseTimeEntity {
+
+    @Version
+    Long version;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -22,6 +28,7 @@ public class Party extends BaseTimeEntity {
     private String content;
     private String imageUrl;
     private int maxCapacity;
+    private int currentCount = 1;
     private LocalDateTime deadline;
     private boolean isClosed;
     private boolean isDeleted;
@@ -62,5 +69,16 @@ public class Party extends BaseTimeEntity {
 
     public boolean hasImageUrl() {
         return this.imageUrl != null && !this.imageUrl.isEmpty();
+    }
+
+    public void addParticipant() {
+        if (currentCount >= maxCapacity) {
+            throw new ApiException(PARTY_CAPACITY_EXCEEDED);
+        }
+        currentCount++;
+    }
+
+    public void removeParticipant() {
+        currentCount--;
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/domain/party/Party.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/party/Party.java
@@ -18,7 +18,7 @@ import static wad.seoul_nolgoat.exception.ErrorCode.PARTY_CAPACITY_EXCEEDED;
 public class Party extends BaseTimeEntity {
 
     @Version
-    Long version;
+    private Long version;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/wad/seoul_nolgoat/domain/party/PartyRepository.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/party/PartyRepository.java
@@ -1,15 +1,14 @@
 package wad.seoul_nolgoat.domain.party;
 
-import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface PartyRepository extends JpaRepository<Party, Long>, PartyRepositoryCustom {
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT p FROM Party p WHERE p.id = :id")
-    Optional<Party> findByIdWithLock(Long id);
+    @Query("SELECT p FROM Party p " +
+            "LEFT JOIN FETCH p.host " +
+            "WHERE p.id = :partyId")
+    Optional<Party> findByIdWithFetchJoin(Long partyId);
 }

--- a/src/main/java/wad/seoul_nolgoat/domain/party/PartyRepository.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/party/PartyRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
-public interface PartyRepository extends JpaRepository<Party, Long> {
+public interface PartyRepository extends JpaRepository<Party, Long>, PartyRepositoryCustom {
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT p FROM Party p WHERE p.id = :id")

--- a/src/main/java/wad/seoul_nolgoat/domain/party/PartyRepositoryCustom.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/party/PartyRepositoryCustom.java
@@ -1,0 +1,10 @@
+package wad.seoul_nolgoat.domain.party;
+
+import org.springframework.data.domain.Page;
+import wad.seoul_nolgoat.web.party.request.PartySearchConditionDto;
+import wad.seoul_nolgoat.web.party.response.PartyListDto;
+
+public interface PartyRepositoryCustom {
+
+    Page<PartyListDto> findAllWithConditionAndPagination(PartySearchConditionDto partySearchConditionDto);
+}

--- a/src/main/java/wad/seoul_nolgoat/domain/party/PartyRepositoryCustom.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/party/PartyRepositoryCustom.java
@@ -4,9 +4,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import wad.seoul_nolgoat.web.party.request.PartySearchConditionDto;
 import wad.seoul_nolgoat.web.party.response.HostedPartyListDto;
+import wad.seoul_nolgoat.web.party.response.PartyDetailsDto;
 import wad.seoul_nolgoat.web.party.response.PartyListDto;
 
 public interface PartyRepositoryCustom {
+
+    PartyDetailsDto findPartyDetailsById(Long partyId);
 
     Page<PartyListDto> findAllWithConditionAndPagination(PartySearchConditionDto partySearchConditionDto);
 

--- a/src/main/java/wad/seoul_nolgoat/domain/party/PartyRepositoryCustom.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/party/PartyRepositoryCustom.java
@@ -1,10 +1,16 @@
 package wad.seoul_nolgoat.domain.party;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import wad.seoul_nolgoat.web.party.request.PartySearchConditionDto;
+import wad.seoul_nolgoat.web.party.response.HostedPartyListDto;
 import wad.seoul_nolgoat.web.party.response.PartyListDto;
 
 public interface PartyRepositoryCustom {
 
     Page<PartyListDto> findAllWithConditionAndPagination(PartySearchConditionDto partySearchConditionDto);
+
+    Page<HostedPartyListDto> findHostedPartiesByLoginId(String loginId, Pageable pageable);
+
+    Page<PartyListDto> findJoinedPartiesByLoginId(String loginId, Pageable pageable);
 }

--- a/src/main/java/wad/seoul_nolgoat/domain/party/PartyRepositoryCustomImpl.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/party/PartyRepositoryCustomImpl.java
@@ -96,7 +96,10 @@ public class PartyRepositoryCustomImpl implements PartyRepositoryCustom {
                 )
                 .from(party)
                 .join(party.host)
-                .where(buildSearchCondition(status, AdministrativeDistrict.valueOf(district)))
+                .where(
+                        buildSearchCondition(status, AdministrativeDistrict.valueOf(district)),
+                        party.isDeleted.isFalse()
+                )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .orderBy(getOrderSpecifier(sortField))
@@ -106,7 +109,10 @@ public class PartyRepositoryCustomImpl implements PartyRepositoryCustom {
                 .select(party.count()) // select count(party.id)
                 .from(party)
                 .join(party.host)
-                .where(buildSearchCondition(status, AdministrativeDistrict.valueOf(district)));
+                .where(
+                        buildSearchCondition(status, AdministrativeDistrict.valueOf(district)),
+                        party.isDeleted.isFalse()
+                );
 
         return PageableExecutionUtils.getPage(parties, pageable, countQuery::fetchOne);
     }
@@ -130,7 +136,10 @@ public class PartyRepositoryCustomImpl implements PartyRepositoryCustom {
                         )
                 )
                 .from(party)
-                .where(party.host.loginId.eq(loginId))
+                .where(
+                        party.host.loginId.eq(loginId),
+                        party.isDeleted.isFalse()
+                )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .orderBy(party.createdDate.desc())
@@ -139,7 +148,10 @@ public class PartyRepositoryCustomImpl implements PartyRepositoryCustom {
         JPAQuery<Long> countQuery = jpaQueryFactory
                 .select(party.count()) // select count(party.id)
                 .from(party)
-                .where(party.host.loginId.eq(loginId));
+                .where(
+                        party.host.loginId.eq(loginId),
+                        party.isDeleted.isFalse()
+                );
 
         return PageableExecutionUtils.getPage(parties, pageable, countQuery::fetchOne);
     }
@@ -168,7 +180,10 @@ public class PartyRepositoryCustomImpl implements PartyRepositoryCustom {
                 .from(party)
                 .join(party.host)
                 .join(partyUser).on(partyUser.party.eq(party))
-                .where(partyUser.participant.loginId.eq(loginId))
+                .where(
+                        partyUser.participant.loginId.eq(loginId),
+                        party.isDeleted.isFalse()
+                )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .orderBy(party.createdDate.desc())
@@ -179,7 +194,10 @@ public class PartyRepositoryCustomImpl implements PartyRepositoryCustom {
                 .from(party)
                 .join(party.host)
                 .join(partyUser).on(partyUser.party.eq(party))
-                .where(partyUser.participant.loginId.eq(loginId));
+                .where(
+                        partyUser.participant.loginId.eq(loginId),
+                        party.isDeleted.isFalse()
+                );
 
         return PageableExecutionUtils.getPage(parties, pageable, countQuery::fetchOne);
     }

--- a/src/main/java/wad/seoul_nolgoat/domain/party/PartyRepositoryCustomImpl.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/party/PartyRepositoryCustomImpl.java
@@ -1,0 +1,84 @@
+package wad.seoul_nolgoat.domain.party;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import wad.seoul_nolgoat.web.party.request.PartySearchConditionDto;
+import wad.seoul_nolgoat.web.party.response.PartyListDto;
+
+import java.util.List;
+
+import static wad.seoul_nolgoat.domain.party.QParty.party;
+import static wad.seoul_nolgoat.domain.party.QPartyUser.partyUser;
+
+@RequiredArgsConstructor
+public class PartyRepositoryCustomImpl implements PartyRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<PartyListDto> findAllWithConditionAndPagination(PartySearchConditionDto partySearchConditionDto) {
+        Pageable pageable = PageRequest.of(partySearchConditionDto.getPage(), partySearchConditionDto.getSize());
+        String status = partySearchConditionDto.getStatus();
+        String district = partySearchConditionDto.getDistrict();
+        String sortField = partySearchConditionDto.getSortField();
+
+        List<PartyListDto> parties = jpaQueryFactory
+                .select(
+                        Projections.constructor(
+                                PartyListDto.class,
+                                party.id,
+                                party.title,
+                                party.maxCapacity,
+                                party.deadline,
+                                party.isClosed,
+                                party.administrativeDistrict,
+                                JPAExpressions
+                                        .select(partyUser.count())
+                                        .from(partyUser)
+                                        .where(partyUser.party.id.eq(party.id)),
+                                party.host.id,
+                                party.host.nickname,
+                                party.host.profileImage
+                        )
+                )
+                .from(party)
+                .where(buildSearchCondition(status, AdministrativeDistrict.valueOf(district)))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(getOrderSpecifier(sortField))
+                .fetch();
+
+        JPAQuery<Long> countQuery = jpaQueryFactory
+                .select(party.count()) // select count(party.id)
+                .from(party)
+                .where(buildSearchCondition(status, AdministrativeDistrict.valueOf(district)));
+
+        return PageableExecutionUtils.getPage(parties, pageable, countQuery::fetchOne);
+    }
+
+    private BooleanExpression buildSearchCondition(String status, AdministrativeDistrict district) {
+        if (status.equals("closed")) {
+            return party.isClosed.isTrue().and(party.administrativeDistrict.eq(district));
+        }
+        if (status.equals("opened")) {
+            return party.isClosed.isFalse().and(party.administrativeDistrict.eq(district));
+        }
+        return party.administrativeDistrict.eq(district);
+    }
+
+    private OrderSpecifier<?> getOrderSpecifier(String sortField) {
+        if (sortField.equals("deadline")) {
+            return party.deadline.desc();
+        }
+        return party.createdDate.desc();
+    }
+}

--- a/src/main/java/wad/seoul_nolgoat/domain/party/PartyRepositoryCustomImpl.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/party/PartyRepositoryCustomImpl.java
@@ -66,13 +66,16 @@ public class PartyRepositoryCustomImpl implements PartyRepositoryCustom {
     }
 
     private BooleanExpression buildSearchCondition(String status, AdministrativeDistrict district) {
+        if (status == null) {
+            return party.administrativeDistrict.eq(district);
+        }
         if (status.equals("closed")) {
             return party.isClosed.isTrue().and(party.administrativeDistrict.eq(district));
         }
         if (status.equals("opened")) {
             return party.isClosed.isFalse().and(party.administrativeDistrict.eq(district));
         }
-        return party.administrativeDistrict.eq(district);
+        return null;
     }
 
     private OrderSpecifier<?> getOrderSpecifier(String sortField) {

--- a/src/main/java/wad/seoul_nolgoat/domain/party/PartyRepositoryCustomImpl.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/party/PartyRepositoryCustomImpl.java
@@ -56,7 +56,8 @@ public class PartyRepositoryCustomImpl implements PartyRepositoryCustom {
                 )
                 .from(party)
                 .join(party.host)
-                .leftJoin(partyUser).on(partyUser.party.eq(party))
+                .leftJoin(partyUser).on(partyUser.party.eq(party)) // inner 조인을 하면 partyUser가 없을 경우, 결과가 null이 됨
+                .leftJoin(partyUser.participant) // inner 조인을 하면 참여자가 없을 경우, 결과가 null이 됨
                 .where(
                         party.id.eq(partyId),
                         party.isDeleted.isFalse()
@@ -167,6 +168,7 @@ public class PartyRepositoryCustomImpl implements PartyRepositoryCustom {
                 .from(party)
                 .join(party.host)
                 .join(partyUser).on(partyUser.party.eq(party))
+                .join(partyUser.participant)
                 .where(
                         partyUser.participant.loginId.eq(loginId),
                         party.isDeleted.isFalse()
@@ -181,6 +183,7 @@ public class PartyRepositoryCustomImpl implements PartyRepositoryCustom {
                 .from(party)
                 .join(party.host)
                 .join(partyUser).on(partyUser.party.eq(party))
+                .join(partyUser.participant)
                 .where(
                         partyUser.participant.loginId.eq(loginId),
                         party.isDeleted.isFalse()

--- a/src/main/java/wad/seoul_nolgoat/domain/party/PartyRepositoryCustomImpl.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/party/PartyRepositoryCustomImpl.java
@@ -3,7 +3,6 @@ package wad.seoul_nolgoat.domain.party;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -41,10 +40,7 @@ public class PartyRepositoryCustomImpl implements PartyRepositoryCustom {
                                 party.deadline,
                                 party.isClosed,
                                 party.administrativeDistrict,
-                                JPAExpressions
-                                        .select(partyUser.count())
-                                        .from(partyUser)
-                                        .where(partyUser.party.id.eq(partyId)),
+                                party.currentCount,
                                 party.host.id,
                                 party.host.nickname,
                                 party.host.profileImage,
@@ -85,10 +81,7 @@ public class PartyRepositoryCustomImpl implements PartyRepositoryCustom {
                                 party.deadline,
                                 party.isClosed,
                                 party.administrativeDistrict,
-                                JPAExpressions
-                                        .select(partyUser.count())
-                                        .from(partyUser)
-                                        .where(partyUser.party.id.eq(party.id)),
+                                party.currentCount,
                                 party.host.id,
                                 party.host.nickname,
                                 party.host.profileImage
@@ -129,10 +122,7 @@ public class PartyRepositoryCustomImpl implements PartyRepositoryCustom {
                                 party.deadline,
                                 party.isClosed,
                                 party.administrativeDistrict,
-                                JPAExpressions
-                                        .select(partyUser.count())
-                                        .from(partyUser)
-                                        .where(partyUser.party.id.eq(party.id))
+                                party.currentCount
                         )
                 )
                 .from(party)
@@ -168,10 +158,7 @@ public class PartyRepositoryCustomImpl implements PartyRepositoryCustom {
                                 party.deadline,
                                 party.isClosed,
                                 party.administrativeDistrict,
-                                JPAExpressions
-                                        .select(partyUser.count())
-                                        .from(partyUser)
-                                        .where(partyUser.party.id.eq(party.id)),
+                                party.currentCount,
                                 party.host.id,
                                 party.host.nickname,
                                 party.host.profileImage

--- a/src/main/java/wad/seoul_nolgoat/domain/party/PartyUserRepository.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/party/PartyUserRepository.java
@@ -1,14 +1,10 @@
 package wad.seoul_nolgoat.domain.party;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface PartyUserRepository extends JpaRepository<PartyUser, Long> {
-
-    @Query("SELECT COUNT(pu) FROM PartyUser pu WHERE pu.party.id = :partyId")
-    int countByPartyId(Long partyId);
 
     boolean existsByPartyIdAndParticipantId(Long partyId, Long participantId);
 

--- a/src/main/java/wad/seoul_nolgoat/exception/ErrorCode.java
+++ b/src/main/java/wad/seoul_nolgoat/exception/ErrorCode.java
@@ -46,8 +46,9 @@ public enum ErrorCode {
     PARTY_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "PARTY006", "이미 삭제된 파티입니다."),
     PARTY_KICK_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "PARTY007", "파티 생성자만 참여자를 추방할 수 있습니다."),
     PARTY_CLOSE_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "PARTY008", "파티 생성자만 파티를 마감할 수 있습니다."),
-    PARTY_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "PARTY009", "해당 파티에 참여하지 않은 유저입니다."),
-    INVALID_ADMINISTRATIVE_DISTRICT(HttpStatus.BAD_REQUEST, "PARTY010", "유효하지 않은 행정구역입니다."),
+    PARTY_DELETE_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "PARTY009", "파티 생성자만 파티를 삭제할 수 있습니다."),
+    PARTY_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "PARTY010", "해당 파티에 참여하지 않은 유저입니다."),
+    INVALID_ADMINISTRATIVE_DISTRICT(HttpStatus.BAD_REQUEST, "PARTY011", "유효하지 않은 행정구역입니다."),
 
     // 건의 관련
     INQUIRY_NOT_FOUND(HttpStatus.NOT_FOUND, "INQUIRY001", "존재하지 않는 건의 사항입니다."),

--- a/src/main/java/wad/seoul_nolgoat/exception/ErrorCode.java
+++ b/src/main/java/wad/seoul_nolgoat/exception/ErrorCode.java
@@ -46,6 +46,7 @@ public enum ErrorCode {
     PARTY_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "PARTY006", "이미 삭제된 파티입니다."),
     PARTY_NOT_HOST(HttpStatus.FORBIDDEN, "PARTY007", "파티 생성자만 참여자를 추방할 수 있습니다."),
     PARTY_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "PARTY008", "해당 파티에 참여하지 않은 유저입니다."),
+    INVALID_ADMINISTRATIVE_DISTRICT(HttpStatus.BAD_REQUEST, "PARTY009", "유효하지 않은 행정구역입니다."),
 
     // 건의 관련
     INQUIRY_NOT_FOUND(HttpStatus.NOT_FOUND, "INQUIRY001", "존재하지 않는 건의 사항입니다."),

--- a/src/main/java/wad/seoul_nolgoat/exception/ErrorCode.java
+++ b/src/main/java/wad/seoul_nolgoat/exception/ErrorCode.java
@@ -44,7 +44,7 @@ public enum ErrorCode {
     PARTY_ALREADY_JOINED(HttpStatus.BAD_REQUEST, "PARTY004", "이미 참여 중인 파티입니다."),
     PARTY_ALREADY_CLOSED(HttpStatus.BAD_REQUEST, "PARTY005", "이미 마감된 파티입니다."),
     PARTY_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "PARTY006", "이미 삭제된 파티입니다."),
-    PARTY_NOT_HOST(HttpStatus.FORBIDDEN, "PARTY007", "파티 생성자만 참여자를 추방할 수 있습니다."),
+    PARTY_KICK_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "PARTY007", "파티 생성자만 참여자를 추방할 수 있습니다."),
     PARTY_CLOSE_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "PARTY008", "파티 생성자만 파티를 마감할 수 있습니다."),
     PARTY_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "PARTY009", "해당 파티에 참여하지 않은 유저입니다."),
     INVALID_ADMINISTRATIVE_DISTRICT(HttpStatus.BAD_REQUEST, "PARTY010", "유효하지 않은 행정구역입니다."),

--- a/src/main/java/wad/seoul_nolgoat/exception/ErrorCode.java
+++ b/src/main/java/wad/seoul_nolgoat/exception/ErrorCode.java
@@ -45,8 +45,9 @@ public enum ErrorCode {
     PARTY_ALREADY_CLOSED(HttpStatus.BAD_REQUEST, "PARTY005", "이미 마감된 파티입니다."),
     PARTY_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "PARTY006", "이미 삭제된 파티입니다."),
     PARTY_NOT_HOST(HttpStatus.FORBIDDEN, "PARTY007", "파티 생성자만 참여자를 추방할 수 있습니다."),
-    PARTY_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "PARTY008", "해당 파티에 참여하지 않은 유저입니다."),
-    INVALID_ADMINISTRATIVE_DISTRICT(HttpStatus.BAD_REQUEST, "PARTY009", "유효하지 않은 행정구역입니다."),
+    PARTY_CLOSE_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "PARTY008", "파티 생성자만 파티를 마감할 수 있습니다."),
+    PARTY_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "PARTY009", "해당 파티에 참여하지 않은 유저입니다."),
+    INVALID_ADMINISTRATIVE_DISTRICT(HttpStatus.BAD_REQUEST, "PARTY010", "유효하지 않은 행정구역입니다."),
 
     // 건의 관련
     INQUIRY_NOT_FOUND(HttpStatus.NOT_FOUND, "INQUIRY001", "존재하지 않는 건의 사항입니다."),

--- a/src/main/java/wad/seoul_nolgoat/service/party/PartyService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/party/PartyService.java
@@ -194,6 +194,8 @@ public class PartyService {
 
     // 파티 리스트 조회
     public Page<PartyListDto> findPartiesWithConditionAndPagination(PartySearchConditionDto partySearchConditionDto) {
+        validateAdministrativeDistrict(partySearchConditionDto.getDistrict());
+        
         return partyRepository.findAllWithConditionAndPagination(partySearchConditionDto);
     }
 

--- a/src/main/java/wad/seoul_nolgoat/service/party/PartyService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/party/PartyService.java
@@ -207,8 +207,8 @@ public class PartyService {
     }
 
     // 내가 참여한 파티 목록 조회
-    public void findJoinedPartiesByLoginId(String loginId, Pageable pageable) {
-
+    public Page<PartyListDto> findJoinedPartiesByLoginId(String loginId, Pageable pageable) {
+        return partyRepository.findJoinedPartiesByLoginId(loginId, pageable);
     }
 
     // 유효한 지역인지 검증

--- a/src/main/java/wad/seoul_nolgoat/service/party/PartyService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/party/PartyService.java
@@ -2,6 +2,7 @@ package wad.seoul_nolgoat.service.party;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -13,6 +14,7 @@ import wad.seoul_nolgoat.service.s3.S3Service;
 import wad.seoul_nolgoat.util.mapper.PartyMapper;
 import wad.seoul_nolgoat.web.party.request.PartySaveDto;
 import wad.seoul_nolgoat.web.party.request.PartySearchConditionDto;
+import wad.seoul_nolgoat.web.party.response.HostedPartyListDto;
 import wad.seoul_nolgoat.web.party.response.PartyDetailsDto;
 import wad.seoul_nolgoat.web.party.response.PartyListDto;
 
@@ -192,11 +194,21 @@ public class PartyService {
         return PartyMapper.toPartyDetailsDto(party, currentCount);
     }
 
-    // 파티 리스트 조회
+    // 파티 목록 조회
     public Page<PartyListDto> findPartiesWithConditionAndPagination(PartySearchConditionDto partySearchConditionDto) {
         validateAdministrativeDistrict(partySearchConditionDto.getDistrict());
-        
+
         return partyRepository.findAllWithConditionAndPagination(partySearchConditionDto);
+    }
+
+    // 내가 만든 파티 목록 조회
+    public Page<HostedPartyListDto> findHostedPartiesByLoginId(String loginId, Pageable pageable) {
+        return partyRepository.findHostedPartiesByLoginId(loginId, pageable);
+    }
+
+    // 내가 참여한 파티 목록 조회
+    public void findJoinedPartiesByLoginId(String loginId, Pageable pageable) {
+
     }
 
     // 유효한 지역인지 검증

--- a/src/main/java/wad/seoul_nolgoat/service/party/PartyService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/party/PartyService.java
@@ -1,6 +1,7 @@
 package wad.seoul_nolgoat.service.party;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -11,7 +12,9 @@ import wad.seoul_nolgoat.exception.ApiException;
 import wad.seoul_nolgoat.service.s3.S3Service;
 import wad.seoul_nolgoat.util.mapper.PartyMapper;
 import wad.seoul_nolgoat.web.party.request.PartySaveDto;
+import wad.seoul_nolgoat.web.party.request.PartySearchConditionDto;
 import wad.seoul_nolgoat.web.party.response.PartyDetailsDto;
+import wad.seoul_nolgoat.web.party.response.PartyListDto;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -190,6 +193,9 @@ public class PartyService {
     }
 
     // 파티 리스트 조회
+    public Page<PartyListDto> findPartiesWithConditionAndPagination(PartySearchConditionDto partySearchConditionDto) {
+        return partyRepository.findAllWithConditionAndPagination(partySearchConditionDto);
+    }
 
     // 유효한 지역인지 검증
     private void validateAdministrativeDistrict(String administrativeDistrict) {

--- a/src/main/java/wad/seoul_nolgoat/service/party/PartyService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/party/PartyService.java
@@ -166,12 +166,16 @@ public class PartyService {
     }
 
     // 파티 단건 조회
-    public PartyDetailsDto findByPartyId(Long partyId) {
+    public PartyDetailsDto findByPartyId(Long partyId, LocalDateTime currentTime) {
         Party party = partyRepository.findById(partyId)
                 .orElseThrow(() -> new ApiException(PARTY_NOT_FOUND));
 
         if (party.isDeleted()) {
             throw new ApiException(PARTY_ALREADY_DELETED);
+        }
+
+        if (party.getDeadline().isBefore(currentTime)) {
+            party.close();
         }
 
         int currentCount = partyUserRepository.countByPartyId(partyId);

--- a/src/main/java/wad/seoul_nolgoat/service/party/PartyService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/party/PartyService.java
@@ -140,6 +140,12 @@ public class PartyService {
         if (party.isDeleted()) {
             throw new ApiException(PARTY_ALREADY_DELETED);
         }
+
+        // s3 이미지 파일 삭제
+        if (party.hasImageUrl()) {
+            s3Service.deleteFile(party.getImageUrl());
+        }
+
         party.delete();
     }
 

--- a/src/main/java/wad/seoul_nolgoat/service/party/PartyService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/party/PartyService.java
@@ -13,6 +13,7 @@ import wad.seoul_nolgoat.util.mapper.PartyMapper;
 import wad.seoul_nolgoat.web.party.request.PartySaveDto;
 import wad.seoul_nolgoat.web.party.response.PartyDetailsDto;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static wad.seoul_nolgoat.exception.ErrorCode.*;
@@ -57,6 +58,14 @@ public class PartyService {
     public void joinParty(String loginId, Long partyId) {
         Party party = partyRepository.findByIdWithLock(partyId)
                 .orElseThrow(() -> new ApiException(PARTY_NOT_FOUND));
+
+        // 파티 마감 날짜 확인
+        LocalDateTime deadline = party.getDeadline();
+        LocalDateTime now = LocalDateTime.now();
+        if (deadline.isBefore(now) || deadline.isEqual(now)) {
+            party.close();
+            throw new ApiException(PARTY_ALREADY_CLOSED);
+        }
 
         // 파티 삭제 여부 확인
         if (party.isDeleted()) {

--- a/src/main/java/wad/seoul_nolgoat/service/party/PartyService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/party/PartyService.java
@@ -55,14 +55,17 @@ public class PartyService {
 
     // 파티 참여
     @Transactional
-    public void joinParty(String loginId, Long partyId) {
+    public void joinParty(
+            String loginId,
+            Long partyId,
+            LocalDateTime currentTime
+    ) {
         Party party = partyRepository.findByIdWithLock(partyId)
                 .orElseThrow(() -> new ApiException(PARTY_NOT_FOUND));
 
         // 파티 마감 날짜 확인
         LocalDateTime deadline = party.getDeadline();
-        LocalDateTime now = LocalDateTime.now();
-        if (deadline.isBefore(now) || deadline.isEqual(now)) {
+        if (deadline.isBefore(currentTime) || deadline.isEqual(currentTime)) {
             party.close();
             throw new ApiException(PARTY_ALREADY_CLOSED);
         }

--- a/src/main/java/wad/seoul_nolgoat/service/party/PartyService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/party/PartyService.java
@@ -177,21 +177,16 @@ public class PartyService {
     }
 
     // 파티 단건 조회
+    @Transactional
     public PartyDetailsDto findByPartyId(Long partyId, LocalDateTime currentTime) {
         Party party = partyRepository.findById(partyId)
                 .orElseThrow(() -> new ApiException(PARTY_NOT_FOUND));
-
-        if (party.isDeleted()) {
-            throw new ApiException(PARTY_ALREADY_DELETED);
-        }
 
         if (party.getDeadline().isBefore(currentTime)) {
             party.close();
         }
 
-        int currentCount = partyUserRepository.countByPartyId(partyId);
-
-        return PartyMapper.toPartyDetailsDto(party, currentCount);
+        return partyRepository.findPartyDetailsById(partyId);
     }
 
     // 파티 목록 조회

--- a/src/main/java/wad/seoul_nolgoat/service/party/PartyService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/party/PartyService.java
@@ -110,9 +110,14 @@ public class PartyService {
 
     // 파티 마감
     @Transactional
-    public void closeById(Long partyId) {
+    public void closeById(String loginId, Long partyId) {
         Party party = partyRepository.findById(partyId)
                 .orElseThrow(() -> new ApiException(PARTY_NOT_FOUND));
+
+        if (!party.getHost().getLoginId().equals(loginId)) {
+            throw new ApiException(PARTY_CLOSE_NOT_AUTHORIZED);
+        }
+
         if (party.isClosed()) {
             throw new ApiException(PARTY_ALREADY_CLOSED);
         }

--- a/src/main/java/wad/seoul_nolgoat/service/party/PartyService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/party/PartyService.java
@@ -4,10 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-import wad.seoul_nolgoat.domain.party.Party;
-import wad.seoul_nolgoat.domain.party.PartyRepository;
-import wad.seoul_nolgoat.domain.party.PartyUser;
-import wad.seoul_nolgoat.domain.party.PartyUserRepository;
+import wad.seoul_nolgoat.domain.party.*;
 import wad.seoul_nolgoat.domain.user.User;
 import wad.seoul_nolgoat.domain.user.UserRepository;
 import wad.seoul_nolgoat.exception.ApiException;
@@ -37,6 +34,8 @@ public class PartyService {
             PartySaveDto partySaveDto,
             MultipartFile image
     ) {
+        validateAdministrativeDistrict(partySaveDto.getAdministrativeDistrict());
+
         User user = userRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new ApiException(USER_NOT_FOUND));
 
@@ -75,7 +74,7 @@ public class PartyService {
         Long userId = user.getId();
 
         // 파티 생성자는 본인의 파티에 참여 신청 불가능
-        if (party.getHost().getId() == userId) {
+        if (party.getHost().getId().equals(userId)) {
             throw new ApiException(PARTY_CREATOR_CANNOT_JOIN);
         }
 
@@ -159,4 +158,13 @@ public class PartyService {
     }
 
     // 파티 리스트 조회
+
+    // 유효한 지역인지 검증
+    private void validateAdministrativeDistrict(String administrativeDistrict) {
+        try {
+            AdministrativeDistrict.valueOf(administrativeDistrict);
+        } catch (IllegalArgumentException e) {
+            throw new ApiException(INVALID_ADMINISTRATIVE_DISTRICT);
+        }
+    }
 }

--- a/src/main/java/wad/seoul_nolgoat/service/party/PartyService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/party/PartyService.java
@@ -129,9 +129,14 @@ public class PartyService {
 
     // 파티 삭제
     @Transactional
-    public void deleteById(Long partyId) {
+    public void deleteById(String loginId, Long partyId) {
         Party party = partyRepository.findById(partyId)
                 .orElseThrow(() -> new ApiException(PARTY_NOT_FOUND));
+
+        if (!party.getHost().getLoginId().equals(loginId)) {
+            throw new ApiException(PARTY_DELETE_NOT_AUTHORIZED);
+        }
+
         if (party.isDeleted()) {
             throw new ApiException(PARTY_ALREADY_DELETED);
         }

--- a/src/main/java/wad/seoul_nolgoat/service/party/PartyService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/party/PartyService.java
@@ -150,7 +150,7 @@ public class PartyService {
 
         // 파티 생성자인지 검증
         if (!party.getHost().getLoginId().equals(loginId)) {
-            throw new ApiException(PARTY_NOT_HOST);
+            throw new ApiException(PARTY_KICK_NOT_AUTHORIZED);
         }
 
         // 밴 대상이 참여자가 맞는지 검증

--- a/src/main/java/wad/seoul_nolgoat/service/party/PartyService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/party/PartyService.java
@@ -178,7 +178,7 @@ public class PartyService {
 
     // 파티 단건 조회
     @Transactional
-    public PartyDetailsDto findByPartyId(Long partyId, LocalDateTime currentTime) {
+    public PartyDetailsDto findPartyDetailsById(Long partyId, LocalDateTime currentTime) {
         Party party = partyRepository.findById(partyId)
                 .orElseThrow(() -> new ApiException(PARTY_NOT_FOUND));
 

--- a/src/main/java/wad/seoul_nolgoat/util/mapper/PartyMapper.java
+++ b/src/main/java/wad/seoul_nolgoat/util/mapper/PartyMapper.java
@@ -18,6 +18,7 @@ public class PartyMapper {
                 imageUrl,
                 partySaveDto.getMaxCapacity(),
                 partySaveDto.getDeadline(),
+                partySaveDto.getAdministrativeDistrict(),
                 user
         );
     }

--- a/src/main/java/wad/seoul_nolgoat/util/mapper/PartyMapper.java
+++ b/src/main/java/wad/seoul_nolgoat/util/mapper/PartyMapper.java
@@ -3,7 +3,6 @@ package wad.seoul_nolgoat.util.mapper;
 import wad.seoul_nolgoat.domain.party.Party;
 import wad.seoul_nolgoat.domain.user.User;
 import wad.seoul_nolgoat.web.party.request.PartySaveDto;
-import wad.seoul_nolgoat.web.party.response.PartyDetailsDto;
 
 public class PartyMapper {
 
@@ -20,19 +19,6 @@ public class PartyMapper {
                 partySaveDto.getDeadline(),
                 partySaveDto.getAdministrativeDistrict(),
                 user
-        );
-    }
-
-    public static PartyDetailsDto toPartyDetailsDto(Party party, int currentCount) {
-        return new PartyDetailsDto(
-                party.getId(),
-                party.getTitle(),
-                party.getContent(),
-                party.getImageUrl(),
-                party.getMaxCapacity(),
-                party.getDeadline(),
-                party.isClosed(),
-                currentCount
         );
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/web/party/PartyController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/party/PartyController.java
@@ -97,7 +97,7 @@ public class PartyController {
     @GetMapping("/{partyId}")
     public ResponseEntity<PartyDetailsDto> showPartyByPartyId(@PathVariable Long partyId) {
         return ResponseEntity
-                .ok(partyService.findByPartyId(partyId, LocalDateTime.now()));
+                .ok(partyService.findPartyDetailsById(partyId, LocalDateTime.now()));
     }
 
     @GetMapping

--- a/src/main/java/wad/seoul_nolgoat/web/party/PartyController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/party/PartyController.java
@@ -113,7 +113,8 @@ public class PartyController {
     }
 
     @GetMapping("/me/joined")
-    public void showMyJoinedParties(@AuthenticationPrincipal OAuth2User loginUser, Pageable pageable) {
-
+    public ResponseEntity<Page<PartyListDto>> showMyJoinedParties(@AuthenticationPrincipal OAuth2User loginUser, Pageable pageable) {
+        return ResponseEntity
+                .ok(partyService.findJoinedPartiesByLoginId(loginUser.getName(), pageable));
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/web/party/PartyController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/party/PartyController.java
@@ -68,8 +68,8 @@ public class PartyController {
     }
 
     @DeleteMapping("/{partyId}")
-    public ResponseEntity<Void> deleteById(@PathVariable Long partyId) {
-        partyService.deleteById(partyId);
+    public ResponseEntity<Void> deleteById(@AuthenticationPrincipal OAuth2User loginUser, @PathVariable Long partyId) {
+        partyService.deleteById(loginUser.getName(), partyId);
 
         return ResponseEntity
                 .noContent()

--- a/src/main/java/wad/seoul_nolgoat/web/party/PartyController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/party/PartyController.java
@@ -92,6 +92,6 @@ public class PartyController {
     @GetMapping("/{partyId}")
     public ResponseEntity<PartyDetailsDto> showPartyByPartyId(@PathVariable Long partyId) {
         return ResponseEntity
-                .ok(partyService.findByPartyId(partyId));
+                .ok(partyService.findByPartyId(partyId, LocalDateTime.now()));
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/web/party/PartyController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/party/PartyController.java
@@ -13,6 +13,7 @@ import wad.seoul_nolgoat.web.party.request.PartySaveDto;
 import wad.seoul_nolgoat.web.party.response.PartyDetailsDto;
 
 import java.net.URI;
+import java.time.LocalDateTime;
 
 @Hidden
 @RequiredArgsConstructor
@@ -46,7 +47,11 @@ public class PartyController {
 
     @PostMapping("/{partyId}/join")
     public ResponseEntity<Void> joinParty(@AuthenticationPrincipal OAuth2User loginUser, @PathVariable Long partyId) {
-        partyService.joinParty(loginUser.getName(), partyId);
+        partyService.joinParty(
+                loginUser.getName(),
+                partyId,
+                LocalDateTime.now()
+        );
 
         return ResponseEntity
                 .ok()

--- a/src/main/java/wad/seoul_nolgoat/web/party/PartyController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/party/PartyController.java
@@ -2,6 +2,7 @@ package wad.seoul_nolgoat.web.party;
 
 import io.swagger.v3.oas.annotations.Hidden;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -10,7 +11,9 @@ import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.util.UriComponentsBuilder;
 import wad.seoul_nolgoat.service.party.PartyService;
 import wad.seoul_nolgoat.web.party.request.PartySaveDto;
+import wad.seoul_nolgoat.web.party.request.PartySearchConditionDto;
 import wad.seoul_nolgoat.web.party.response.PartyDetailsDto;
+import wad.seoul_nolgoat.web.party.response.PartyListDto;
 
 import java.net.URI;
 import java.time.LocalDateTime;
@@ -93,5 +96,11 @@ public class PartyController {
     public ResponseEntity<PartyDetailsDto> showPartyByPartyId(@PathVariable Long partyId) {
         return ResponseEntity
                 .ok(partyService.findByPartyId(partyId, LocalDateTime.now()));
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<PartyListDto>> showPartiesByCondition(PartySearchConditionDto partySearchConditionDto) {
+        return ResponseEntity
+                .ok(partyService.findPartiesWithConditionAndPagination(partySearchConditionDto));
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/web/party/PartyController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/party/PartyController.java
@@ -3,6 +3,7 @@ package wad.seoul_nolgoat.web.party;
 import io.swagger.v3.oas.annotations.Hidden;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -12,6 +13,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 import wad.seoul_nolgoat.service.party.PartyService;
 import wad.seoul_nolgoat.web.party.request.PartySaveDto;
 import wad.seoul_nolgoat.web.party.request.PartySearchConditionDto;
+import wad.seoul_nolgoat.web.party.response.HostedPartyListDto;
 import wad.seoul_nolgoat.web.party.response.PartyDetailsDto;
 import wad.seoul_nolgoat.web.party.response.PartyListDto;
 
@@ -102,5 +104,16 @@ public class PartyController {
     public ResponseEntity<Page<PartyListDto>> showPartiesByCondition(PartySearchConditionDto partySearchConditionDto) {
         return ResponseEntity
                 .ok(partyService.findPartiesWithConditionAndPagination(partySearchConditionDto));
+    }
+
+    @GetMapping("/me/created")
+    public ResponseEntity<Page<HostedPartyListDto>> showMyHostedParties(@AuthenticationPrincipal OAuth2User loginUser, Pageable pageable) {
+        return ResponseEntity
+                .ok(partyService.findHostedPartiesByLoginId(loginUser.getName(), pageable));
+    }
+
+    @GetMapping("/me/joined")
+    public void showMyJoinedParties(@AuthenticationPrincipal OAuth2User loginUser, Pageable pageable) {
+
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/web/party/PartyController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/party/PartyController.java
@@ -54,8 +54,8 @@ public class PartyController {
     }
 
     @PostMapping("/{partyId}")
-    public ResponseEntity<Void> closeById(@PathVariable Long partyId) {
-        partyService.closeById(partyId);
+    public ResponseEntity<Void> closeById(@AuthenticationPrincipal OAuth2User loginUser, @PathVariable Long partyId) {
+        partyService.closeById(loginUser.getName(), partyId);
 
         return ResponseEntity
                 .ok()

--- a/src/main/java/wad/seoul_nolgoat/web/party/request/PartySaveDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/party/request/PartySaveDto.java
@@ -13,5 +13,5 @@ public class PartySaveDto {
     private final String content;
     private final int maxCapacity;
     private final LocalDateTime deadline;
-    private String administrativeDistrict;
+    private final String administrativeDistrict;
 }

--- a/src/main/java/wad/seoul_nolgoat/web/party/request/PartySaveDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/party/request/PartySaveDto.java
@@ -13,7 +13,5 @@ public class PartySaveDto {
     private final String content;
     private final int maxCapacity;
     private final LocalDateTime deadline;
-
-    // 지역 추가
-    // private Enum? location;
+    private String administrativeDistrict;
 }

--- a/src/main/java/wad/seoul_nolgoat/web/party/request/PartySaveDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/party/request/PartySaveDto.java
@@ -1,5 +1,6 @@
 package wad.seoul_nolgoat.web.party.request;
 
+import jakarta.validation.constraints.*;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -9,9 +10,22 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor
 public class PartySaveDto {
 
+    @NotBlank
+    @Size(max = 25, message = "제목은 25자 이내여야 합니다.")
     private final String title;
+
+    @NotBlank
+    @Size(max = 300, message = "내용은 300자 이내여야 합니다.")
     private final String content;
+
+    @Min(value = 2, message = "참여 가능 인원은 본인 제외 1명 이상이어야 합니다.")
+    @Max(value = 30, message = "참여 가능 인원은 30명을 초과할 수 없습니다.")
     private final int maxCapacity;
+
+    @NotNull
+    @Future(message = "마감시간은 현재 시간 이후여야 합니다.")
     private final LocalDateTime deadline;
+
+    @NotBlank
     private final String administrativeDistrict;
 }

--- a/src/main/java/wad/seoul_nolgoat/web/party/request/PartySearchConditionDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/party/request/PartySearchConditionDto.java
@@ -1,0 +1,13 @@
+package wad.seoul_nolgoat.web.party.request;
+
+import lombok.Getter;
+
+@Getter
+public class PartySearchConditionDto {
+
+    private String status; // 전체 or 모집 중 or 마감
+    private String district; // 지역(행정구역)
+    private int page;
+    private int size;
+    private String sortField; // 정렬 대상
+}

--- a/src/main/java/wad/seoul_nolgoat/web/party/request/PartySearchConditionDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/party/request/PartySearchConditionDto.java
@@ -1,13 +1,21 @@
 package wad.seoul_nolgoat.web.party.request;
 
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
+@Builder
 public class PartySearchConditionDto {
 
-    private String status; // 전체 or 모집 중 or 마감
-    private String district; // 지역(행정구역)
-    private int page;
-    private int size;
-    private String sortField; // 정렬 대상
+    private String status; // opened or closed or null
+    private String district; // 구역
+
+    @Builder.Default
+    private int page = 0;
+
+    @Builder.Default
+    private int size = 10;
+
+    @Builder.Default
+    private String sortField = "createdDate"; // 정렬 대상
 }

--- a/src/main/java/wad/seoul_nolgoat/web/party/response/HostedPartyListDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/party/response/HostedPartyListDto.java
@@ -23,7 +23,7 @@ public class HostedPartyListDto {
             LocalDateTime deadline,
             boolean isClosed,
             AdministrativeDistrict district,
-            Long currentCount
+            int currentCount
     ) {
         this.partyId = partyId;
         this.title = title;
@@ -31,6 +31,6 @@ public class HostedPartyListDto {
         this.deadline = deadline;
         this.isClosed = isClosed;
         this.district = district.getDisplayName();
-        this.currentCount = currentCount.intValue() + 1;
+        this.currentCount = currentCount;
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/web/party/response/HostedPartyListDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/party/response/HostedPartyListDto.java
@@ -1,0 +1,36 @@
+package wad.seoul_nolgoat.web.party.response;
+
+import lombok.Getter;
+import wad.seoul_nolgoat.domain.party.AdministrativeDistrict;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class HostedPartyListDto {
+
+    private final Long partyId;
+    private final String title;
+    private final int maxCapacity;
+    private final LocalDateTime deadline;
+    private final boolean isClosed;
+    private final String district;
+    private final int currentCount;
+
+    public HostedPartyListDto(
+            Long partyId,
+            String title,
+            int maxCapacity,
+            LocalDateTime deadline,
+            boolean isClosed,
+            AdministrativeDistrict district,
+            Long currentCount
+    ) {
+        this.partyId = partyId;
+        this.title = title;
+        this.maxCapacity = maxCapacity;
+        this.deadline = deadline;
+        this.isClosed = isClosed;
+        this.district = district.getDisplayName();
+        this.currentCount = currentCount.intValue() + 1;
+    }
+}

--- a/src/main/java/wad/seoul_nolgoat/web/party/response/ParticipantDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/party/response/ParticipantDto.java
@@ -1,0 +1,13 @@
+package wad.seoul_nolgoat.web.party.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ParticipantDto {
+
+    private final Long userId;
+    private final String nickname;
+    private final String profileImage;
+}

--- a/src/main/java/wad/seoul_nolgoat/web/party/response/PartyDetailsDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/party/response/PartyDetailsDto.java
@@ -32,7 +32,7 @@ public class PartyDetailsDto {
             LocalDateTime deadline,
             boolean isClosed,
             AdministrativeDistrict district,
-            Long currentCount,
+            int currentCount,
             Long hostId,
             String hostNickname,
             String hostProfileImage,
@@ -46,7 +46,7 @@ public class PartyDetailsDto {
         this.deadline = deadline;
         this.isClosed = isClosed;
         this.district = district.getDisplayName();
-        this.currentCount = currentCount.intValue() + 1;
+        this.currentCount = currentCount;
         this.hostId = hostId;
         this.hostNickname = hostNickname;
         this.hostProfileImage = hostProfileImage;

--- a/src/main/java/wad/seoul_nolgoat/web/party/response/PartyDetailsDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/party/response/PartyDetailsDto.java
@@ -1,12 +1,12 @@
 package wad.seoul_nolgoat.web.party.response;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import wad.seoul_nolgoat.domain.party.AdministrativeDistrict;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
-@RequiredArgsConstructor
 public class PartyDetailsDto {
 
     private final Long id;
@@ -16,5 +16,40 @@ public class PartyDetailsDto {
     private final int maxCapacity;
     private final LocalDateTime deadline;
     private final boolean isClosed;
+    private final String district;
     private final int currentCount;
+    private final Long hostId;
+    private final String hostNickname;
+    private final String hostProfileImage;
+    private final List<ParticipantDto> participants;
+
+    public PartyDetailsDto(
+            Long id,
+            String title,
+            String content,
+            String imageUrl,
+            int maxCapacity,
+            LocalDateTime deadline,
+            boolean isClosed,
+            AdministrativeDistrict district,
+            Long currentCount,
+            Long hostId,
+            String hostNickname,
+            String hostProfileImage,
+            List<ParticipantDto> participants
+    ) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.imageUrl = imageUrl;
+        this.maxCapacity = maxCapacity;
+        this.deadline = deadline;
+        this.isClosed = isClosed;
+        this.district = district.getDisplayName();
+        this.currentCount = currentCount.intValue() + 1;
+        this.hostId = hostId;
+        this.hostNickname = hostNickname;
+        this.hostProfileImage = hostProfileImage;
+        this.participants = participants;
+    }
 }

--- a/src/main/java/wad/seoul_nolgoat/web/party/response/PartyListDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/party/response/PartyListDto.java
@@ -26,7 +26,7 @@ public class PartyListDto {
             LocalDateTime deadline,
             boolean isClosed,
             AdministrativeDistrict district,
-            int currentCount,
+            Long currentCount,
             Long hostId,
             String hostNickname,
             String hostProfileImage
@@ -37,7 +37,7 @@ public class PartyListDto {
         this.deadline = deadline;
         this.isClosed = isClosed;
         this.district = district.getDisplayName();
-        this.currentCount = currentCount;
+        this.currentCount = currentCount.intValue();
         this.hostId = hostId;
         this.hostNickname = hostNickname;
         this.hostProfileImage = hostProfileImage;

--- a/src/main/java/wad/seoul_nolgoat/web/party/response/PartyListDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/party/response/PartyListDto.java
@@ -37,7 +37,7 @@ public class PartyListDto {
         this.deadline = deadline;
         this.isClosed = isClosed;
         this.district = district.getDisplayName();
-        this.currentCount = currentCount.intValue();
+        this.currentCount = currentCount.intValue() + 1;
         this.hostId = hostId;
         this.hostNickname = hostNickname;
         this.hostProfileImage = hostProfileImage;

--- a/src/main/java/wad/seoul_nolgoat/web/party/response/PartyListDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/party/response/PartyListDto.java
@@ -26,7 +26,7 @@ public class PartyListDto {
             LocalDateTime deadline,
             boolean isClosed,
             AdministrativeDistrict district,
-            Long currentCount,
+            int currentCount,
             Long hostId,
             String hostNickname,
             String hostProfileImage
@@ -37,7 +37,7 @@ public class PartyListDto {
         this.deadline = deadline;
         this.isClosed = isClosed;
         this.district = district.getDisplayName();
-        this.currentCount = currentCount.intValue() + 1;
+        this.currentCount = currentCount;
         this.hostId = hostId;
         this.hostNickname = hostNickname;
         this.hostProfileImage = hostProfileImage;

--- a/src/main/java/wad/seoul_nolgoat/web/party/response/PartyListDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/party/response/PartyListDto.java
@@ -1,0 +1,45 @@
+package wad.seoul_nolgoat.web.party.response;
+
+import lombok.Getter;
+import wad.seoul_nolgoat.domain.party.AdministrativeDistrict;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class PartyListDto {
+
+    private final Long partyId;
+    private final String title;
+    private final int maxCapacity;
+    private final LocalDateTime deadline;
+    private final boolean isClosed;
+    private final String district;
+    private final int currentCount;
+    private final Long hostId;
+    private final String hostNickname;
+    private final String hostProfileImage;
+
+    public PartyListDto(
+            Long partyId,
+            String title,
+            int maxCapacity,
+            LocalDateTime deadline,
+            boolean isClosed,
+            AdministrativeDistrict district,
+            int currentCount,
+            Long hostId,
+            String hostNickname,
+            String hostProfileImage
+    ) {
+        this.partyId = partyId;
+        this.title = title;
+        this.maxCapacity = maxCapacity;
+        this.deadline = deadline;
+        this.isClosed = isClosed;
+        this.district = district.getDisplayName();
+        this.currentCount = currentCount;
+        this.hostId = hostId;
+        this.hostNickname = hostNickname;
+        this.hostProfileImage = hostProfileImage;
+    }
+}

--- a/src/test/java/wad/seoul_nolgoat/service/PartyServiceTest.java
+++ b/src/test/java/wad/seoul_nolgoat/service/PartyServiceTest.java
@@ -340,9 +340,10 @@ public class PartyServiceTest {
     void find_party_details() {
         // given
         Long partyId = 1L;
+        LocalDateTime currentTime = LocalDateTime.of(2024, 9, 10, 0, 0, 0);
 
         // when // then
-        assertThat(partyService.findByPartyId(partyId))
+        assertThat(partyService.findByPartyId(partyId, currentTime))
                 .extracting(
                         "id",
                         "title",

--- a/src/test/java/wad/seoul_nolgoat/service/PartyServiceTest.java
+++ b/src/test/java/wad/seoul_nolgoat/service/PartyServiceTest.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
+import wad.seoul_nolgoat.domain.party.AdministrativeDistrict;
 import wad.seoul_nolgoat.domain.party.PartyRepository;
 import wad.seoul_nolgoat.domain.party.PartyUserRepository;
 import wad.seoul_nolgoat.exception.ApiException;
@@ -50,15 +51,16 @@ public class PartyServiceTest {
         String content = "맛있는 돈까스";
         int maxCapacity = 4;
         LocalDateTime deadline = LocalDateTime.of(2024, 11, 11, 12, 0);
-        PartySaveDto partySaveDto = new PartySaveDto(title, content, maxCapacity, deadline);
+        String administrativeDistrict = "GANGNAM_GU";
+        PartySaveDto partySaveDto = new PartySaveDto(title, content, maxCapacity, deadline, administrativeDistrict);
 
         // when
         Long partyId = partyService.createParty(loginId, partySaveDto, null);
 
         // then
         assertThat(partyRepository.findById(partyId).get())
-                .extracting("title", "content", "maxCapacity", "deadline")
-                .containsExactly(title, content, maxCapacity, deadline);
+                .extracting("title", "content", "maxCapacity", "deadline", "administrativeDistrict")
+                .containsExactly(title, content, maxCapacity, deadline, AdministrativeDistrict.GANGNAM_GU);
     }
 
     @DisplayName("동시에 여러 유저가 파티에 가입 신청을 해도, 최대 인원을 초과하지 않습니다.")
@@ -71,7 +73,7 @@ public class PartyServiceTest {
 
         Long partyId = 1L;
         String loginIdPrefix = "user";
-        LocalDateTime currentTime = LocalDateTime.parse("2024-09-10T00:00:00");
+        LocalDateTime currentTime = LocalDateTime.of(2024, 9, 10, 0, 0, 0);
         for (int i = 2; i <= threadCount + 1; i++) {
             String loginId = loginIdPrefix + i;
             executorService.submit(() -> {
@@ -96,7 +98,7 @@ public class PartyServiceTest {
         // given
         String loginId = "user2";
         Long partyId = 5L;
-        LocalDateTime currentTime = LocalDateTime.parse("2024-09-10T00:00:00");
+        LocalDateTime currentTime = LocalDateTime.of(2024, 9, 10, 0, 0, 0);
 
         // when // then
         assertThatThrownBy(() -> partyService.joinParty(loginId, partyId, currentTime))
@@ -110,7 +112,7 @@ public class PartyServiceTest {
         // given
         String loginId = "user2";
         Long partyId = 4L;
-        LocalDateTime currentTime = LocalDateTime.parse("2024-09-10T00:00:00");
+        LocalDateTime currentTime = LocalDateTime.of(2024, 9, 10, 0, 0, 0);
 
         // when // then
         assertThatThrownBy(() -> partyService.joinParty(loginId, partyId, currentTime))
@@ -124,7 +126,7 @@ public class PartyServiceTest {
         // given
         String loginId = "user1";
         Long partyId = 1L;
-        LocalDateTime currentTime = LocalDateTime.parse("2024-09-10T00:00:00");
+        LocalDateTime currentTime = LocalDateTime.of(2024, 9, 10, 0, 0, 0);
 
         // when // then
         assertThatThrownBy(() -> partyService.joinParty(loginId, partyId, currentTime))
@@ -138,7 +140,7 @@ public class PartyServiceTest {
         // given
         String loginIdB = "user2";
         Long partyId = 1L;
-        LocalDateTime currentTime = LocalDateTime.parse("2024-09-10T00:00:00");
+        LocalDateTime currentTime = LocalDateTime.of(2024, 9, 10, 0, 0, 0);
 
         partyService.joinParty(loginIdB, partyId, currentTime);
 
@@ -157,7 +159,7 @@ public class PartyServiceTest {
         String loginIdD = "user4";
         String loginIdE = "user5";
         Long partyId = 3L;
-        LocalDateTime currentTime = LocalDateTime.parse("2024-09-10T00:00:00");
+        LocalDateTime currentTime = LocalDateTime.of(2024, 9, 10, 0, 0, 0);
 
         partyService.joinParty(loginIdA, partyId, currentTime);
         partyService.joinParty(loginIdB, partyId, currentTime);
@@ -245,7 +247,7 @@ public class PartyServiceTest {
         String hostLoginId = "user1";
         String participantLoginId = "user2";
         Long partyId = 1L;
-        LocalDateTime currentTime = LocalDateTime.parse("2024-09-10T00:00:00");
+        LocalDateTime currentTime = LocalDateTime.of(2024, 9, 10, 0, 0, 0);
 
         partyService.joinParty(participantLoginId, partyId, currentTime);
 
@@ -263,7 +265,7 @@ public class PartyServiceTest {
         String loginId = "user3";
         String participantLoginId = "user2";
         Long partyId = 1L;
-        LocalDateTime currentTime = LocalDateTime.parse("2024-09-10T00:00:00");
+        LocalDateTime currentTime = LocalDateTime.of(2024, 9, 10, 0, 0, 0);
 
         partyService.joinParty(participantLoginId, partyId, currentTime);
 

--- a/src/test/java/wad/seoul_nolgoat/service/PartyServiceTest.java
+++ b/src/test/java/wad/seoul_nolgoat/service/PartyServiceTest.java
@@ -71,11 +71,12 @@ public class PartyServiceTest {
 
         Long partyId = 1L;
         String loginIdPrefix = "user";
+        LocalDateTime currentTime = LocalDateTime.parse("2024-09-10T00:00:00");
         for (int i = 2; i <= threadCount + 1; i++) {
             String loginId = loginIdPrefix + i;
             executorService.submit(() -> {
                 try {
-                    partyService.joinParty(loginId, partyId);
+                    partyService.joinParty(loginId, partyId, currentTime);
                 } catch (ApiException e) {
                     System.out.println(e.getErrorCode().getMessage());
                 } finally {
@@ -95,9 +96,10 @@ public class PartyServiceTest {
         // given
         String loginId = "user2";
         Long partyId = 5L;
+        LocalDateTime currentTime = LocalDateTime.parse("2024-09-10T00:00:00");
 
         // when // then
-        assertThatThrownBy(() -> partyService.joinParty(loginId, partyId))
+        assertThatThrownBy(() -> partyService.joinParty(loginId, partyId, currentTime))
                 .isInstanceOf(ApiException.class)
                 .hasMessage(PARTY_ALREADY_DELETED.getMessage());
     }
@@ -108,9 +110,10 @@ public class PartyServiceTest {
         // given
         String loginId = "user2";
         Long partyId = 4L;
+        LocalDateTime currentTime = LocalDateTime.parse("2024-09-10T00:00:00");
 
         // when // then
-        assertThatThrownBy(() -> partyService.joinParty(loginId, partyId))
+        assertThatThrownBy(() -> partyService.joinParty(loginId, partyId, currentTime))
                 .isInstanceOf(ApiException.class)
                 .hasMessage(PARTY_ALREADY_CLOSED.getMessage());
     }
@@ -121,9 +124,10 @@ public class PartyServiceTest {
         // given
         String loginId = "user1";
         Long partyId = 1L;
+        LocalDateTime currentTime = LocalDateTime.parse("2024-09-10T00:00:00");
 
         // when // then
-        assertThatThrownBy(() -> partyService.joinParty(loginId, partyId))
+        assertThatThrownBy(() -> partyService.joinParty(loginId, partyId, currentTime))
                 .isInstanceOf(ApiException.class)
                 .hasMessage(PARTY_CREATOR_CANNOT_JOIN.getMessage());
     }
@@ -134,11 +138,12 @@ public class PartyServiceTest {
         // given
         String loginIdB = "user2";
         Long partyId = 1L;
+        LocalDateTime currentTime = LocalDateTime.parse("2024-09-10T00:00:00");
 
-        partyService.joinParty(loginIdB, partyId);
+        partyService.joinParty(loginIdB, partyId, currentTime);
 
         // when // then
-        assertThatThrownBy(() -> partyService.joinParty(loginIdB, partyId))
+        assertThatThrownBy(() -> partyService.joinParty(loginIdB, partyId, currentTime))
                 .isInstanceOf(ApiException.class)
                 .hasMessage(PARTY_ALREADY_JOINED.getMessage());
     }
@@ -152,13 +157,14 @@ public class PartyServiceTest {
         String loginIdD = "user4";
         String loginIdE = "user5";
         Long partyId = 3L;
+        LocalDateTime currentTime = LocalDateTime.parse("2024-09-10T00:00:00");
 
-        partyService.joinParty(loginIdA, partyId);
-        partyService.joinParty(loginIdB, partyId);
-        partyService.joinParty(loginIdD, partyId);
+        partyService.joinParty(loginIdA, partyId, currentTime);
+        partyService.joinParty(loginIdB, partyId, currentTime);
+        partyService.joinParty(loginIdD, partyId, currentTime);
 
         // when // then
-        assertThatThrownBy(() -> partyService.joinParty(loginIdE, partyId))
+        assertThatThrownBy(() -> partyService.joinParty(loginIdE, partyId, currentTime))
                 .isInstanceOf(ApiException.class)
                 .hasMessage(PARTY_CAPACITY_EXCEEDED.getMessage());
     }
@@ -170,10 +176,11 @@ public class PartyServiceTest {
     @Test
     void close_party() {
         // given
+        String loginId = "user1";
         Long partyId = 1L;
 
         // when
-        partyService.closeById(partyId);
+        partyService.closeById(loginId, partyId);
 
         // then
         assertThat(partyRepository.findById(partyId).get().isClosed()).isTrue();
@@ -183,10 +190,11 @@ public class PartyServiceTest {
     @Test
     void throw_exception_when_trying_to_close_already_closed_party() {
         // given
+        String loginId = "user1";
         Long partyId = 4L;
 
         // when // then
-        assertThatThrownBy(() -> partyService.closeById(partyId))
+        assertThatThrownBy(() -> partyService.closeById(loginId, partyId))
                 .isInstanceOf(ApiException.class)
                 .hasMessage(PARTY_ALREADY_CLOSED.getMessage());
     }
@@ -224,8 +232,9 @@ public class PartyServiceTest {
         String hostLoginId = "user1";
         String participantLoginId = "user2";
         Long partyId = 1L;
+        LocalDateTime currentTime = LocalDateTime.parse("2024-09-10T00:00:00");
 
-        partyService.joinParty(participantLoginId, partyId);
+        partyService.joinParty(participantLoginId, partyId, currentTime);
 
         // when
         partyService.banParticipantFromParty(hostLoginId, partyId, 2L);
@@ -241,8 +250,9 @@ public class PartyServiceTest {
         String loginId = "user3";
         String participantLoginId = "user2";
         Long partyId = 1L;
+        LocalDateTime currentTime = LocalDateTime.parse("2024-09-10T00:00:00");
 
-        partyService.joinParty(participantLoginId, partyId);
+        partyService.joinParty(participantLoginId, partyId, currentTime);
 
         // when // then
         assertThatThrownBy(() -> partyService.banParticipantFromParty(loginId, partyId, 2L))

--- a/src/test/java/wad/seoul_nolgoat/service/PartyServiceTest.java
+++ b/src/test/java/wad/seoul_nolgoat/service/PartyServiceTest.java
@@ -110,6 +110,20 @@ public class PartyServiceTest {
         assertThat(partyUserRepository.countByPartyId(1L)).isEqualTo(5);
     }
 
+    @DisplayName("마감 시간이 지난 파티에 참여 신청을 하면, 예외가 발생합니다.")
+    @Test
+    void throw_exception_when_joining_party_after_deadline() {
+        // given
+        String loginId = "user2";
+        Long partyId = 3L;
+        LocalDateTime currentTime = LocalDateTime.of(2025, 1, 1, 0, 0, 0);
+
+        // when // then
+        assertThatThrownBy(() -> partyService.joinParty(loginId, partyId, currentTime))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(PARTY_ALREADY_CLOSED.getMessage());
+    }
+
     @DisplayName("이미 삭제된 파티에 참여 신청을 하면, 예외가 발생합니다.")
     @Test
     void apply_join_request_when_party_is_already_deleted_then_throw_exception() {

--- a/src/test/java/wad/seoul_nolgoat/service/PartyServiceTest.java
+++ b/src/test/java/wad/seoul_nolgoat/service/PartyServiceTest.java
@@ -186,6 +186,19 @@ public class PartyServiceTest {
         assertThat(partyRepository.findById(partyId).get().isClosed()).isTrue();
     }
 
+    @DisplayName("파티 생성자가 아닌 유저가 파티를 마감하려 하면, 예외가 발생합니다.")
+    @Test
+    void throw_exception_when_trying_to_close_party_by_non_host() {
+        // given
+        String loginId = "user2";
+        Long partyId = 3L;
+
+        // when // then
+        assertThatThrownBy(() -> partyService.closeById(loginId, partyId))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(PARTY_CLOSE_NOT_AUTHORIZED.getMessage());
+    }
+
     @DisplayName("이미 마감된 파티를 마감하려 하면, 예외가 발생합니다.")
     @Test
     void throw_exception_when_trying_to_close_already_closed_party() {

--- a/src/test/java/wad/seoul_nolgoat/service/PartyServiceTest.java
+++ b/src/test/java/wad/seoul_nolgoat/service/PartyServiceTest.java
@@ -365,4 +365,35 @@ public class PartyServiceTest {
                         0
                 );
     }
+
+    @DisplayName("파티 단건 조회 시, 마감일이 지났으면, 파티의 isClosed 상태를 true로 변경합니다.")
+    @Test
+    void update_party_to_closed_when_finding_party_after_deadline() {
+        // given
+        Long partyId = 1L;
+        LocalDateTime currentTime = LocalDateTime.of(2025, 1, 1, 0, 0, 0);
+
+        // when // then
+        assertThat(partyService.findByPartyId(partyId, currentTime))
+                .extracting(
+                        "id",
+                        "title",
+                        "content",
+                        "imageUrl",
+                        "maxCapacity",
+                        "deadline",
+                        "isClosed",
+                        "currentCount"
+                )
+                .containsExactly(
+                        1L,
+                        "PartyA",
+                        "Party Content A",
+                        null,
+                        6,
+                        LocalDateTime.of(2024, 12, 31, 23, 59, 59),
+                        true,
+                        0
+                );
+    }
 }

--- a/src/test/java/wad/seoul_nolgoat/service/PartyServiceTest.java
+++ b/src/test/java/wad/seoul_nolgoat/service/PartyServiceTest.java
@@ -270,7 +270,7 @@ public class PartyServiceTest {
         // when // then
         assertThatThrownBy(() -> partyService.banParticipantFromParty(loginId, partyId, 2L))
                 .isInstanceOf(ApiException.class)
-                .hasMessage(PARTY_NOT_HOST.getMessage());
+                .hasMessage(PARTY_KICK_NOT_AUTHORIZED.getMessage());
     }
 
     @DisplayName("추방 대상인 유저가 파티의 참여자가 아니라면, 예외가 발생합니다.")

--- a/src/test/java/wad/seoul_nolgoat/service/PartyServiceTest.java
+++ b/src/test/java/wad/seoul_nolgoat/service/PartyServiceTest.java
@@ -251,23 +251,38 @@ public class PartyServiceTest {
     @Test
     void delete_party() {
         // given
+        String loginId = "user1";
         Long partyId = 1L;
 
         // when
-        partyService.deleteById(partyId);
+        partyService.deleteById(loginId, partyId);
 
         // then
         assertThat(partyRepository.findById(partyId).get().isDeleted()).isTrue();
+    }
+
+    @DisplayName("파티 생성자가 아닌 유저가 파티를 삭제하려 하면, 예외가 발생합니다.")
+    @Test
+    void throw_exception_when_trying_to_delete_party_by_non_host() {
+        // given
+        String loginId = "user1";
+        Long partyId = 5L;
+
+        // when // then
+        assertThatThrownBy(() -> partyService.deleteById(loginId, partyId))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(PARTY_DELETE_NOT_AUTHORIZED.getMessage());
     }
 
     @DisplayName("이미 삭제된 파티를 삭제하려 하면, 예외가 발생합니다.")
     @Test
     void throw_exception_when_trying_to_delete_already_deleted_party() {
         // given
+        String loginId = "user4";
         Long partyId = 5L;
 
         // when // then
-        assertThatThrownBy(() -> partyService.deleteById(partyId))
+        assertThatThrownBy(() -> partyService.deleteById(loginId, partyId))
                 .isInstanceOf(ApiException.class)
                 .hasMessage(PARTY_ALREADY_DELETED.getMessage());
     }

--- a/src/test/java/wad/seoul_nolgoat/service/PartyServiceTest.java
+++ b/src/test/java/wad/seoul_nolgoat/service/PartyServiceTest.java
@@ -63,6 +63,24 @@ public class PartyServiceTest {
                 .containsExactly(title, content, maxCapacity, deadline, AdministrativeDistrict.GANGNAM_GU);
     }
 
+    @DisplayName("파티 생성 시, 잘못된 행정구역을 사용하면, 예외가 발생홥니다.")
+    @Test
+    void throw_exception_when_creating_party_with_invalid_district() {
+        // given
+        String loginId = "user1";
+        String title = "돈까스 드실 분~";
+        String content = "맛있는 돈까스";
+        int maxCapacity = 4;
+        LocalDateTime deadline = LocalDateTime.of(2024, 11, 11, 12, 0);
+        String administrativeDistrict = "GANGNAM_GO";
+        PartySaveDto partySaveDto = new PartySaveDto(title, content, maxCapacity, deadline, administrativeDistrict);
+
+        // when // then
+        assertThatThrownBy(() -> partyService.createParty(loginId, partySaveDto, null))
+                .isInstanceOf(ApiException.class)
+                .hasMessage(INVALID_ADMINISTRATIVE_DISTRICT.getMessage());
+    }
+
     @DisplayName("동시에 여러 유저가 파티에 가입 신청을 해도, 최대 인원을 초과하지 않습니다.")
     @Test
     void prevent_exceeding_max_capacity_with_concurrent_requests() throws InterruptedException {

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -31,13 +31,16 @@ VALUES ('NORMAL', 'user1', 'password1', 'UserA', null, 'MALE', '1990-01-01', fal
        ('NORMAL', 'user30', 'password30', 'UserDD', null, 'FEMALE', '2011-06-30', false),
        ('NORMAL', 'user31', 'password31', 'UserEE', null, 'MALE', '2005-02-24', false);
 
-INSERT INTO party (title, content, image_url, max_capacity, deadline, administrative_district, is_closed, is_deleted,
+INSERT INTO party (version, title, content, image_url, max_capacity, current_count, deadline, administrative_district,
+                   is_closed,
+                   is_deleted,
                    host_id)
-VALUES ('PartyA', 'Party Content A', null, 6, '2024-12-31T23:59:59', 'GANGNAM_GU', false, false, 1),
-       ('PartyB', 'Party Content B', null, 5, '2024-11-15T18:00:00', 'SEOCHO_GU', false, false, 2),
-       ('PartyC', 'Party Content C', null, 4, '2024-11-30T12:00:00', 'MAPO_GU', false, false, 3),
-       ('PartyD', 'Party Content D', null, 4, '2024-11-11T11:11:11', 'GANGNAM_GU', true, false, 1),
-       ('PartyE', 'Party Content E', null, 4, '2024-12-12T12:12:12', 'SEOCHO_GU', true, true, 4);
+VALUES (0, 'PartyA', 'Party Content A', null, 6, 1, '2024-12-31T23:59:59', 'GANGNAM_GU', false, false, 1),
+       (0, 'PartyB', 'Party Content B', null, 6, 1, '2024-12-31T23:59:59', 'GANGNAM_GU', false, false, 1),
+       (0, 'PartyC', 'Party Content C', null, 4, 1, '2024-11-30T12:00:00', 'MAPO_GU', false, false, 3),
+       (0, 'PartyD', 'Party Content D', null, 4, 1, '2024-11-11T11:11:11', 'GANGNAM_GU', true, false, 1),
+       (0, 'PartyE', 'Party Content E', null, 4, 1, '2024-12-12T12:12:12', 'SEOCHO_GU', true, true, 4),
+       (0, 'PartyF', 'Party Content F', null, 5, 1, '2024-11-15T18:00:00', 'SEOCHO_GU', false, false, 2);
 
 INSERT INTO inquiry (user_id, title, content, is_public, created_date, last_modified_date)
 VALUES (1, 'InquiryA', 'ContentA', true, '2024-12-01T10:00:00', '2024-12-01T10:10:00'),

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -31,12 +31,13 @@ VALUES ('NORMAL', 'user1', 'password1', 'UserA', null, 'MALE', '1990-01-01', fal
        ('NORMAL', 'user30', 'password30', 'UserDD', null, 'FEMALE', '2011-06-30', false),
        ('NORMAL', 'user31', 'password31', 'UserEE', null, 'MALE', '2005-02-24', false);
 
-INSERT INTO party (title, content, image_url, max_capacity, deadline, is_closed, is_deleted, host_id)
-VALUES ('PartyA', 'Party Content A', null, 6, '2024-12-31T23:59:59', false, false, 1),
-       ('PartyB', 'Party Content B', null, 5, '2024-11-15T18:00:00', false, false, 2),
-       ('PartyC', 'Party Content C', null, 4, '2024-11-30T12:00:00', false, false, 3),
-       ('PartyD', 'Party Content D', null, 4, '2024-11-11T11:11:11', true, false, 1),
-       ('PartyE', 'Party Content E', null, 4, '2024-12-12T12:12:12', true, true, 4);
+INSERT INTO party (title, content, image_url, max_capacity, deadline, administrative_district, is_closed, is_deleted,
+                   host_id)
+VALUES ('PartyA', 'Party Content A', null, 6, '2024-12-31T23:59:59', 'GANGNAM_GU', false, false, 1),
+       ('PartyB', 'Party Content B', null, 5, '2024-11-15T18:00:00', 'SEOCHO_GU', false, false, 2),
+       ('PartyC', 'Party Content C', null, 4, '2024-11-30T12:00:00', 'MAPO_GU', false, false, 3),
+       ('PartyD', 'Party Content D', null, 4, '2024-11-11T11:11:11', 'GANGNAM_GU', true, false, 1),
+       ('PartyE', 'Party Content E', null, 4, '2024-12-12T12:12:12', 'SEOCHO_GU', true, true, 4);
 
 INSERT INTO inquiry (user_id, title, content, is_public, created_date, last_modified_date)
 VALUES (1, 'InquiryA', 'ContentA', true, '2024-12-01T10:00:00', '2024-12-01T10:10:00'),


### PR DESCRIPTION
## ✔️ 작업 내용

- **필드 추가**
  - 조회마다 카운트 쿼리를 사용하는 대신, 파티 필드에 현재 인원수를 나타내는 `currentCount`를 추가했습니다.
  - 지역(`행정구역`)을 나타내는 `Enum` 타입의 필드, `AdministrativeDistrict`를 추가했습니다.<br>(강남구, 강서구, 강동구 등)
- **검증 로직 추가**
  - 파티 생성 시, 마감일과 지역을 검증합니다.
  - 파티 참여 시, 마감일을 검증합니다.
  - 파티 마감 및 삭제 시, 호스트가 맞는지 검증합니다.
- 파티 삭제 시, `S3`에 업로드된 연관된 이미지 삭제
- **조회 기능 구현**
  - 단건 조회 시, 참여자 목록도 가져옵니다.
  - 목록 조회
    - 조건(지역, 마감 여부, 정렬 대상, 등)으로 전체 목록을 조회합니다.
    - 내가 생성한 파티 목록을 조회합니다.
    - 내가 참여한 파티 목록을 조회합니다.
- **낙관적 락**
  - 파티 참여 로직에 `비관적` 락을 사용 중인데, 충돌이 거의 없을 것으로 판단되어, `낙관적` 락을 사용하도록 수정했습니다.

## 📋 요약

- 파티 필드에 지역(`행정구역`), 현재 인원수 추가
- 파티 생성, 참여, 마감, 삭제 시 검증 로직 추가
- 파티 삭제 시, `S3`에 업로드된 연관된 이미지 삭제
- 조회 기능 구현
  - 단건 조회
  - 기본 목록 조회
  - 내가 생성한 파티 목록 조회
  - 내가 참여한 파티 목록 조회
- 파티 참여에 `비관적` 락 대신 `낙관적` 락 사용

## 🔒 관련 이슈

close #67 

## ➕ 기타 사항

- 파티 수정 미완
- 마감 날짜 대신 모임 날짜를 사용할지 고민