### PR TITLE
유저 ID를 통한 리뷰 및 북마크 목록 조회 기능 수정

### DIFF
--- a/src/main/java/wad/seoul_nolgoat/domain/bookmark/BookmarkRepository.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/bookmark/BookmarkRepository.java
@@ -2,12 +2,9 @@ package wad.seoul_nolgoat.domain.bookmark;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long>, BookmarkRepositoryCustom {
-
-    List<Bookmark> findByUserId(Long userId);
 
     Optional<Bookmark> findByUserIdAndStoreId(Long userId, Long storeId);
 

--- a/src/main/java/wad/seoul_nolgoat/domain/bookmark/BookmarkRepository.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/bookmark/BookmarkRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Optional;
 
-public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long>, BookmarkRepositoryCustom {
 
     List<Bookmark> findByUserId(Long userId);
 

--- a/src/main/java/wad/seoul_nolgoat/domain/bookmark/BookmarkRepositoryCustom.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/bookmark/BookmarkRepositoryCustom.java
@@ -1,0 +1,10 @@
+package wad.seoul_nolgoat.domain.bookmark;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import wad.seoul_nolgoat.web.store.dto.response.StoreForBookmarkDto;
+
+public interface BookmarkRepositoryCustom {
+
+    Page<StoreForBookmarkDto> findBookmarkedStoresByLoginId(String loginId, Pageable pageable);
+}

--- a/src/main/java/wad/seoul_nolgoat/domain/bookmark/BookmarkRepositoryCustom.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/bookmark/BookmarkRepositoryCustom.java
@@ -2,7 +2,7 @@ package wad.seoul_nolgoat.domain.bookmark;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import wad.seoul_nolgoat.web.store.dto.response.StoreForBookmarkDto;
+import wad.seoul_nolgoat.web.bookmark.dto.response.StoreForBookmarkDto;
 
 public interface BookmarkRepositoryCustom {
 

--- a/src/main/java/wad/seoul_nolgoat/domain/bookmark/BookmarkRepositoryCustomImpl.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/bookmark/BookmarkRepositoryCustomImpl.java
@@ -1,0 +1,55 @@
+package wad.seoul_nolgoat.domain.bookmark;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import wad.seoul_nolgoat.web.store.dto.response.StoreForBookmarkDto;
+
+import java.util.List;
+
+import static wad.seoul_nolgoat.domain.bookmark.QBookmark.bookmark;
+
+@RequiredArgsConstructor
+public class BookmarkRepositoryCustomImpl implements BookmarkRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<StoreForBookmarkDto> findBookmarkedStoresByLoginId(String loginId, Pageable pageable) {
+        List<StoreForBookmarkDto> bookmarks = jpaQueryFactory
+                .select(
+                        Projections.constructor(
+                                StoreForBookmarkDto.class,
+                                bookmark.id,
+                                bookmark.store.id,
+                                bookmark.store.storeType,
+                                bookmark.store.name,
+                                bookmark.store.lotAddress,
+                                bookmark.store.roadAddress,
+                                bookmark.store.kakaoAverageGrade,
+                                bookmark.store.nolgoatAverageGrade
+                        )
+                )
+                .from(bookmark)
+                .join(bookmark.store)
+                .join(bookmark.user)
+                .where(bookmark.user.loginId.eq(loginId))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(bookmark.createdDate.desc())
+                .fetch();
+
+        JPAQuery<Long> countQuery = jpaQueryFactory
+                .select(bookmark.count()) // select count(bookmark.id)
+                .from(bookmark)
+                .join(bookmark.store)
+                .join(bookmark.user)
+                .where(bookmark.user.loginId.eq(loginId));
+
+        return PageableExecutionUtils.getPage(bookmarks, pageable, countQuery::fetchOne);
+    }
+}

--- a/src/main/java/wad/seoul_nolgoat/domain/bookmark/BookmarkRepositoryCustomImpl.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/bookmark/BookmarkRepositoryCustomImpl.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
-import wad.seoul_nolgoat.web.store.dto.response.StoreForBookmarkDto;
+import wad.seoul_nolgoat.web.bookmark.dto.response.StoreForBookmarkDto;
 
 import java.util.List;
 

--- a/src/main/java/wad/seoul_nolgoat/domain/review/ReviewRepository.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/review/ReviewRepository.java
@@ -2,11 +2,7 @@ package wad.seoul_nolgoat.domain.review;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-
 public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRepositoryCustom {
-
-    List<Review> findByUserId(Long userId);
 
     boolean existsByUserIdAndStoreId(Long userId, Long storeId);
 }

--- a/src/main/java/wad/seoul_nolgoat/domain/review/ReviewRepository.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/review/ReviewRepository.java
@@ -4,7 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface ReviewRepository extends JpaRepository<Review, Long> {
+public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRepositoryCustom {
 
     List<Review> findByUserId(Long userId);
 

--- a/src/main/java/wad/seoul_nolgoat/domain/review/ReviewRepositoryCustom.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/review/ReviewRepositoryCustom.java
@@ -1,0 +1,10 @@
+package wad.seoul_nolgoat.domain.review;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import wad.seoul_nolgoat.web.review.dto.response.ReviewDetailsForUserDto;
+
+public interface ReviewRepositoryCustom {
+
+    Page<ReviewDetailsForUserDto> findReviewDetailsByLoginId(String loginId, Pageable pageable);
+}

--- a/src/main/java/wad/seoul_nolgoat/domain/review/ReviewRepositoryCustomImpl.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/review/ReviewRepositoryCustomImpl.java
@@ -1,0 +1,53 @@
+package wad.seoul_nolgoat.domain.review;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import wad.seoul_nolgoat.web.review.dto.response.ReviewDetailsForUserDto;
+
+import java.util.List;
+
+import static wad.seoul_nolgoat.domain.review.QReview.review;
+
+@RequiredArgsConstructor
+public class ReviewRepositoryCustomImpl implements ReviewRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<ReviewDetailsForUserDto> findReviewDetailsByLoginId(String loginId, Pageable pageable) {
+        List<ReviewDetailsForUserDto> reviews = jpaQueryFactory
+                .select(
+                        Projections.constructor(
+                                ReviewDetailsForUserDto.class,
+                                review.id,
+                                review.grade,
+                                review.content,
+                                review.imageUrl,
+                                review.store.id,
+                                review.store.name
+                        )
+                )
+                .from(review)
+                .join(review.store)
+                .join(review.user)
+                .where(review.user.loginId.eq(loginId))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(review.createdDate.desc())
+                .fetch();
+
+        JPAQuery<Long> countQuery = jpaQueryFactory
+                .select(review.count()) // select count(review.id)
+                .from(review)
+                .join(review.store)
+                .join(review.user)
+                .where(review.user.loginId.eq(loginId));
+
+        return PageableExecutionUtils.getPage(reviews, pageable, countQuery::fetchOne);
+    }
+}

--- a/src/main/java/wad/seoul_nolgoat/service/bookmark/BookmarkService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/bookmark/BookmarkService.java
@@ -1,6 +1,8 @@
 package wad.seoul_nolgoat.service.bookmark;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import wad.seoul_nolgoat.domain.bookmark.Bookmark;
@@ -10,10 +12,7 @@ import wad.seoul_nolgoat.domain.store.StoreRepository;
 import wad.seoul_nolgoat.domain.user.User;
 import wad.seoul_nolgoat.domain.user.UserRepository;
 import wad.seoul_nolgoat.exception.ApiException;
-import wad.seoul_nolgoat.util.mapper.StoreMapper;
 import wad.seoul_nolgoat.web.store.dto.response.StoreForBookmarkDto;
-
-import java.util.List;
 
 import static wad.seoul_nolgoat.exception.ErrorCode.*;
 
@@ -59,12 +58,8 @@ public class BookmarkService {
         bookmarkRepository.delete(bookmark);
     }
 
-    public List<StoreForBookmarkDto> findBookmarkedStoresByUserId(Long userId) {
-        List<Bookmark> bookmarks = bookmarkRepository.findByUserId(userId);
-
-        return bookmarks.stream()
-                .map(bookmark -> StoreMapper.toStoreForBookmarkDto(bookmark.getStore()))
-                .toList();
+    public Page<StoreForBookmarkDto> findBookmarkedStoresByLoginId(String loginId, Pageable pageable) {
+        return bookmarkRepository.findBookmarkedStoresByLoginId(loginId, pageable);
     }
 
     public boolean checkIfBookmarked(Long userId, Long storeId) {

--- a/src/main/java/wad/seoul_nolgoat/service/bookmark/BookmarkService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/bookmark/BookmarkService.java
@@ -12,7 +12,7 @@ import wad.seoul_nolgoat.domain.store.StoreRepository;
 import wad.seoul_nolgoat.domain.user.User;
 import wad.seoul_nolgoat.domain.user.UserRepository;
 import wad.seoul_nolgoat.exception.ApiException;
-import wad.seoul_nolgoat.web.store.dto.response.StoreForBookmarkDto;
+import wad.seoul_nolgoat.web.bookmark.dto.response.StoreForBookmarkDto;
 
 import static wad.seoul_nolgoat.exception.ErrorCode.*;
 

--- a/src/main/java/wad/seoul_nolgoat/service/review/ReviewService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/review/ReviewService.java
@@ -1,6 +1,8 @@
 package wad.seoul_nolgoat.service.review;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -17,7 +19,6 @@ import wad.seoul_nolgoat.web.review.dto.request.ReviewSaveDto;
 import wad.seoul_nolgoat.web.review.dto.request.ReviewUpdateDto;
 import wad.seoul_nolgoat.web.review.dto.response.ReviewDetailsForUserDto;
 
-import java.util.List;
 import java.util.Optional;
 
 import static wad.seoul_nolgoat.exception.ErrorCode.*;
@@ -65,12 +66,8 @@ public class ReviewService {
         ).getId();
     }
 
-    public List<ReviewDetailsForUserDto> findByUserId(Long userId) {
-        List<Review> reviews = reviewRepository.findByUserId(userId);
-
-        return reviews.stream()
-                .map(ReviewMapper::toReviewDetailsForUserDto)
-                .toList();
+    public Page<ReviewDetailsForUserDto> findByUserId(String loginId, Pageable pageable) {
+        return reviewRepository.findReviewDetailsByLoginId(loginId, pageable);
     }
 
     @Transactional

--- a/src/main/java/wad/seoul_nolgoat/service/review/ReviewService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/review/ReviewService.java
@@ -66,7 +66,7 @@ public class ReviewService {
         ).getId();
     }
 
-    public Page<ReviewDetailsForUserDto> findByUserId(String loginId, Pageable pageable) {
+    public Page<ReviewDetailsForUserDto> findReviewDetailsByLoginId(String loginId, Pageable pageable) {
         return reviewRepository.findReviewDetailsByLoginId(loginId, pageable);
     }
 

--- a/src/main/java/wad/seoul_nolgoat/util/mapper/ReviewMapper.java
+++ b/src/main/java/wad/seoul_nolgoat/util/mapper/ReviewMapper.java
@@ -5,7 +5,6 @@ import wad.seoul_nolgoat.domain.store.Store;
 import wad.seoul_nolgoat.domain.user.User;
 import wad.seoul_nolgoat.web.review.dto.request.ReviewSaveDto;
 import wad.seoul_nolgoat.web.review.dto.response.ReviewDetailsForStoreDto;
-import wad.seoul_nolgoat.web.review.dto.response.ReviewDetailsForUserDto;
 
 import static wad.seoul_nolgoat.util.DateTimeUtil.formatDate;
 
@@ -23,16 +22,6 @@ public class ReviewMapper {
                 imageUrl,
                 user,
                 store
-        );
-    }
-
-    public static ReviewDetailsForUserDto toReviewDetailsForUserDto(Review review) {
-        return new ReviewDetailsForUserDto(
-                review.getGrade(),
-                review.getContent(),
-                review.getImageUrl(),
-                review.getStore().getId(),
-                review.getStore().getName()
         );
     }
 

--- a/src/main/java/wad/seoul_nolgoat/util/mapper/StoreMapper.java
+++ b/src/main/java/wad/seoul_nolgoat/util/mapper/StoreMapper.java
@@ -5,7 +5,6 @@ import wad.seoul_nolgoat.domain.store.Store;
 import wad.seoul_nolgoat.service.search.dto.StoreForDistanceSortDto;
 import wad.seoul_nolgoat.service.search.dto.StoreForGradeSortDto;
 import wad.seoul_nolgoat.web.store.dto.response.StoreDetailsDto;
-import wad.seoul_nolgoat.web.store.dto.response.StoreForBookmarkDto;
 import wad.seoul_nolgoat.web.store.dto.response.StoreForCombinationDto;
 
 import java.util.List;
@@ -52,18 +51,6 @@ public class StoreMapper {
                 storeForGradeSortDto.getCoordinate(),
                 storeForGradeSortDto.getKakaoAverageGrade(),
                 storeForGradeSortDto.getNolgoatAverageGrade()
-        );
-    }
-
-    public static StoreForBookmarkDto toStoreForBookmarkDto(Store store) {
-        return new StoreForBookmarkDto(
-                store.getId(),
-                store.getStoreType(),
-                store.getName(),
-                store.getLotAddress(),
-                store.getRoadAddress(),
-                store.getKakaoAverageGrade(),
-                store.getNolgoatAverageGrade()
         );
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/web/bookmark/dto/response/StoreForBookmarkDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/bookmark/dto/response/StoreForBookmarkDto.java
@@ -1,4 +1,4 @@
-package wad.seoul_nolgoat.web.store.dto.response;
+package wad.seoul_nolgoat.web.bookmark.dto.response;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/wad/seoul_nolgoat/web/review/dto/response/ReviewDetailsForUserDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/review/dto/response/ReviewDetailsForUserDto.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ReviewDetailsForUserDto {
 
+    private final Long id;
     private final int grade;
     private final String content;
     private final String imageUrl;

--- a/src/main/java/wad/seoul_nolgoat/web/store/dto/response/StoreForBookmarkDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/store/dto/response/StoreForBookmarkDto.java
@@ -9,6 +9,7 @@ import wad.seoul_nolgoat.domain.store.StoreType;
 public class StoreForBookmarkDto {
 
     private final Long id;
+    private final Long storeId;
     private final StoreType storeType;
     private final String name;
     private final String lotAddress;

--- a/src/main/java/wad/seoul_nolgoat/web/user/UserController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/user/UserController.java
@@ -2,8 +2,11 @@ package wad.seoul_nolgoat.web.user;
 
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -12,15 +15,15 @@ import org.springframework.web.util.UriComponentsBuilder;
 import wad.seoul_nolgoat.service.bookmark.BookmarkService;
 import wad.seoul_nolgoat.service.review.ReviewService;
 import wad.seoul_nolgoat.service.user.UserService;
+import wad.seoul_nolgoat.web.bookmark.dto.response.StoreForBookmarkDto;
 import wad.seoul_nolgoat.web.review.dto.response.ReviewDetailsForUserDto;
-import wad.seoul_nolgoat.web.store.dto.response.StoreForBookmarkDto;
 import wad.seoul_nolgoat.web.user.dto.request.UserSaveDto;
 import wad.seoul_nolgoat.web.user.dto.request.UserUpdateDto;
 import wad.seoul_nolgoat.web.user.dto.response.UserProfileDto;
 
 import java.net.URI;
-import java.util.List;
 
+@Tag(name = "유저")
 @RequiredArgsConstructor
 @RequestMapping("/api/users")
 @RestController
@@ -67,17 +70,23 @@ public class UserController {
                 .build();
     }
 
-    @Operation(summary = "유저 ID를 통한 즐겨찾기 가게 목록 조회")
-    @GetMapping("/{userId}/bookmarks")
-    public ResponseEntity<List<StoreForBookmarkDto>> showBookmarkedStoresByUserId(@PathVariable Long userId) {
+    @Operation(summary = "내가 등록한 즐겨찾기 가게 목록 조회")
+    @GetMapping("/me/bookmarks")
+    public ResponseEntity<Page<StoreForBookmarkDto>> showMyBookmarkedStores(
+            @AuthenticationPrincipal OAuth2User loginUser,
+            Pageable pageable
+    ) {
         return ResponseEntity
-                .ok(bookmarkService.findBookmarkedStoresByUserId(userId));
+                .ok(bookmarkService.findBookmarkedStoresByLoginId(loginUser.getName(), pageable));
     }
 
-    @Operation(summary = "유저 ID를 통한 리뷰 목록 조회")
-    @GetMapping("/{userId}/reviews")
-    public ResponseEntity<List<ReviewDetailsForUserDto>> showReviewsByUserId(@PathVariable Long userId) {
+    @Operation(summary = "내가 작성한 리뷰 목록 조회")
+    @GetMapping("/me/reviews")
+    public ResponseEntity<Page<ReviewDetailsForUserDto>> showMyReviews(
+            @AuthenticationPrincipal OAuth2User loginUser,
+            Pageable pageable
+    ) {
         return ResponseEntity
-                .ok(reviewService.findByUserId(userId));
+                .ok(reviewService.findReviewDetailsByLoginId(loginUser.getName(), pageable));
     }
 }


### PR DESCRIPTION
## ✔️ 작업 내용

- 유저 ID를 통한 리뷰 목록 조회 기능을 로그인 유저의 리뷰 목록 조회로 수정했습니다.
- 유저 ID를 통한 북마크 목록 조회 기능을 로그인 유저의 북마크 목록 조회로 수정했습니다.

## 📋 요약

- 기존의 리뷰 및 북마크 목록 조회를 내가 작성한 리뷰와 내가 추가한 북마크로 수정

## 🔒 관련 이슈

close #88

## ➕ 기타 사항