### PR TITLE
예외 변환 시, 기존 예외를 포함하도록 수정

### DIFF
--- a/src/main/java/wad/seoul_nolgoat/auth/oauth2/security/CustomOAuth2UserService.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/oauth2/security/CustomOAuth2UserService.java
@@ -11,7 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import wad.seoul_nolgoat.auth.oauth2.dto.GoogleResponse;
 import wad.seoul_nolgoat.auth.oauth2.dto.KakaoResponse;
 import wad.seoul_nolgoat.auth.service.AuthService;
-import wad.seoul_nolgoat.exception.ApiException;
+import wad.seoul_nolgoat.exception.ApplicationException;
 
 import static wad.seoul_nolgoat.exception.ErrorCode.UNSUPPORTED_PROVIDER;
 
@@ -39,6 +39,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             return authService.processOAuth2User(new GoogleResponse(oAuth2User.getAttributes()));
         }
         log.error("Unsupported OAuth2 provider: {}", registrationId);
-        throw new ApiException(UNSUPPORTED_PROVIDER);
+        throw new ApplicationException(UNSUPPORTED_PROVIDER);
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/auth/security/AuthFilter.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/security/AuthFilter.java
@@ -14,7 +14,7 @@ import wad.seoul_nolgoat.auth.oauth2.dto.OAuth2UserDto;
 import wad.seoul_nolgoat.auth.oauth2.dto.OAuth2UserImpl;
 import wad.seoul_nolgoat.auth.service.AuthService;
 import wad.seoul_nolgoat.auth.util.AuthUrlManager;
-import wad.seoul_nolgoat.exception.ApiException;
+import wad.seoul_nolgoat.exception.ApplicationException;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -37,7 +37,7 @@ public class AuthFilter extends OncePerRequestFilter {
             authService.verifyAuthorizationHeader(authorizationHeader);
             accessToken = authorizationHeader.split(" ")[1];
             authService.verifyAccessToken(accessToken);
-        } catch (JwtException | ApiException e) {
+        } catch (JwtException | ApplicationException e) {
             request.setAttribute("exception", e);
             filterChain.doFilter(request, response);
             return;

--- a/src/main/java/wad/seoul_nolgoat/auth/security/AuthenticationEntryPointImpl.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/security/AuthenticationEntryPointImpl.java
@@ -11,7 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
-import wad.seoul_nolgoat.exception.ApiException;
+import wad.seoul_nolgoat.exception.ApplicationException;
 import wad.seoul_nolgoat.exception.dto.response.ErrorResponse;
 
 import java.io.IOException;
@@ -41,10 +41,10 @@ public class AuthenticationEntryPointImpl implements AuthenticationEntryPoint {
             response.getWriter().write(objectMapper.writeValueAsString(new ErrorResponse(INVALID_TOKEN_FORMAT)));
             return;
         }
-        if (exception instanceof ApiException) {
+        if (exception instanceof ApplicationException) {
             response.setStatus(HttpStatus.UNAUTHORIZED.value());
             response.setContentType("application/json;charset=UTF-8");
-            response.getWriter().write(objectMapper.writeValueAsString(new ErrorResponse(((ApiException) exception).getErrorCode())));
+            response.getWriter().write(objectMapper.writeValueAsString(new ErrorResponse(((ApplicationException) exception).getErrorCode())));
         }
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/auth/service/AuthService.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/service/AuthService.java
@@ -12,7 +12,7 @@ import wad.seoul_nolgoat.auth.jwt.JwtProvider;
 import wad.seoul_nolgoat.auth.oauth2.client.SocialClientService;
 import wad.seoul_nolgoat.auth.oauth2.client.TokenResponse;
 import wad.seoul_nolgoat.auth.oauth2.dto.OAuth2Response;
-import wad.seoul_nolgoat.exception.ApiException;
+import wad.seoul_nolgoat.exception.ApplicationException;
 import wad.seoul_nolgoat.service.user.UserService;
 
 import java.util.Objects;
@@ -95,36 +95,36 @@ public class AuthService {
 
             // 캐시에 해당 Refresh 토큰이 존재하는지 확인
             if (!Objects.equals(redisTokenService.getToken(key), refreshToken)) {
-                throw new ApiException(REFRESH_TOKEN_NOT_FOUND);
+                throw new ApplicationException(REFRESH_TOKEN_NOT_FOUND);
             }
 
             // 토큰 발급자가 올바른지 확인
             if (jwtProvider.isTokenNotIssuedByDomain(refreshToken)) {
-                throw new ApiException(INVALID_TOKEN_ISSUER);
+                throw new ApplicationException(INVALID_TOKEN_ISSUER);
             }
 
             // 토큰 타입이 Refresh인지 확인
             if (!jwtProvider.getType(refreshToken).equals(CLAIM_TYPE_REFRESH)) {
-                throw new ApiException(INVALID_TOKEN_TYPE);
+                throw new ApplicationException(INVALID_TOKEN_TYPE);
             }
         } catch (ExpiredJwtException e) {
             deleteRefreshTokenCookie(response);
-            throw new ApiException(TOKEN_EXPIRED, e);
+            throw new ApplicationException(TOKEN_EXPIRED, e);
         } catch (JwtException e) { // ExpiredJwtException을 제외한 나머지 JwtException 처리
-            throw new ApiException(INVALID_TOKEN_FORMAT, e);
+            throw new ApplicationException(INVALID_TOKEN_FORMAT, e);
         }
     }
 
     public void verifyCsrfProtectionUuid(String csrfProtectionUuid) {
         if (!this.csrfProtectionUuid.equals(csrfProtectionUuid)) {
-            throw new ApiException(INVALID_CSRF_PROTECTION_UUID);
+            throw new ApplicationException(INVALID_CSRF_PROTECTION_UUID);
         }
     }
 
     // 인증 헤더 검증
     public void verifyAuthorizationHeader(String authorizationHeader) {
         if (authorizationHeader == null || !authorizationHeader.startsWith(BEARER_PREFIX)) {
-            throw new ApiException(INVALID_AUTHORIZATION_HEADER);
+            throw new ApplicationException(INVALID_AUTHORIZATION_HEADER);
         }
     }
 
@@ -134,17 +134,17 @@ public class AuthService {
 
         // Access 토큰 블랙리스트 여부 확인
         if (Objects.equals(redisTokenService.getToken(key), accessToken)) {
-            throw new ApiException(ACCESS_TOKEN_BLACKLISTED);
+            throw new ApplicationException(ACCESS_TOKEN_BLACKLISTED);
         }
 
         // 토큰 발급자가 올바른지 확인
         if (jwtProvider.isTokenNotIssuedByDomain(accessToken)) {
-            throw new ApiException(INVALID_TOKEN_ISSUER);
+            throw new ApplicationException(INVALID_TOKEN_ISSUER);
         }
 
         // 토큰 타입이 Access인지 확인
         if (!jwtProvider.getType(accessToken).equals(CLAIM_TYPE_ACCESS)) {
-            throw new ApiException(INVALID_TOKEN_TYPE);
+            throw new ApplicationException(INVALID_TOKEN_TYPE);
         }
     }
 
@@ -227,7 +227,7 @@ public class AuthService {
 
         // 인증 번호 만료
         if (storedCode == null) {
-            throw new ApiException(WITHDRAWAL_CODE_EXPIRED);
+            throw new ApplicationException(WITHDRAWAL_CODE_EXPIRED);
         }
 
         return inputCode.equals(storedCode);

--- a/src/main/java/wad/seoul_nolgoat/auth/service/AuthService.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/service/AuthService.java
@@ -109,9 +109,9 @@ public class AuthService {
             }
         } catch (ExpiredJwtException e) {
             deleteRefreshTokenCookie(response);
-            throw new ApiException(TOKEN_EXPIRED);
+            throw new ApiException(TOKEN_EXPIRED, e);
         } catch (JwtException e) { // ExpiredJwtException을 제외한 나머지 JwtException 처리
-            throw new ApiException(INVALID_TOKEN_FORMAT);
+            throw new ApiException(INVALID_TOKEN_FORMAT, e);
         }
     }
 

--- a/src/main/java/wad/seoul_nolgoat/domain/party/Party.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/party/Party.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import wad.seoul_nolgoat.domain.BaseTimeEntity;
 import wad.seoul_nolgoat.domain.user.User;
-import wad.seoul_nolgoat.exception.ApiException;
+import wad.seoul_nolgoat.exception.ApplicationException;
 
 import java.time.LocalDateTime;
 
@@ -73,7 +73,7 @@ public class Party extends BaseTimeEntity {
 
     public void addParticipant() {
         if (currentCount >= maxCapacity) {
-            throw new ApiException(PARTY_CAPACITY_EXCEEDED);
+            throw new ApplicationException(PARTY_CAPACITY_EXCEEDED);
         }
         currentCount++;
     }

--- a/src/main/java/wad/seoul_nolgoat/domain/store/StoreCategory.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/store/StoreCategory.java
@@ -1,6 +1,6 @@
 package wad.seoul_nolgoat.domain.store;
 
-import wad.seoul_nolgoat.exception.ApiException;
+import wad.seoul_nolgoat.exception.ApplicationException;
 
 import java.util.Arrays;
 import java.util.List;
@@ -107,7 +107,7 @@ public enum StoreCategory {
         try {
             return StoreCategory.valueOf(category.toUpperCase()).getCategoryNames();
         } catch (IllegalArgumentException e) {
-            throw new ApiException(CATEGORY_NOT_FOUND, e);
+            throw new ApplicationException(CATEGORY_NOT_FOUND, e);
         }
     }
 

--- a/src/main/java/wad/seoul_nolgoat/domain/store/StoreCategory.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/store/StoreCategory.java
@@ -107,7 +107,7 @@ public enum StoreCategory {
         try {
             return StoreCategory.valueOf(category.toUpperCase()).getCategoryNames();
         } catch (IllegalArgumentException e) {
-            throw new ApiException(CATEGORY_NOT_FOUND);
+            throw new ApiException(CATEGORY_NOT_FOUND, e);
         }
     }
 

--- a/src/main/java/wad/seoul_nolgoat/exception/ApiException.java
+++ b/src/main/java/wad/seoul_nolgoat/exception/ApiException.java
@@ -11,4 +11,9 @@ public class ApiException extends RuntimeException {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
+
+    public ApiException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
 }

--- a/src/main/java/wad/seoul_nolgoat/exception/ApplicationException.java
+++ b/src/main/java/wad/seoul_nolgoat/exception/ApplicationException.java
@@ -3,16 +3,17 @@ package wad.seoul_nolgoat.exception;
 import lombok.Getter;
 
 @Getter
-public class ApiException extends RuntimeException {
+public class ApplicationException extends RuntimeException {
 
     private final ErrorCode errorCode;
 
-    public ApiException(ErrorCode errorCode) {
+    public ApplicationException(ErrorCode errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
 
-    public ApiException(ErrorCode errorCode, Throwable cause) {
+    // 기존 예외를 포함하기 위한 생성자
+    public ApplicationException(ErrorCode errorCode, Throwable cause) {
         super(errorCode.getMessage(), cause);
         this.errorCode = errorCode;
     }

--- a/src/main/java/wad/seoul_nolgoat/exception/ErrorCode.java
+++ b/src/main/java/wad/seoul_nolgoat/exception/ErrorCode.java
@@ -63,12 +63,14 @@ public enum ErrorCode {
     INVALID_SEARCH_CRITERIA(HttpStatus.BAD_REQUEST, "SEARCH001", "유효하지 않은 검색 기준입니다."),
     INVALID_GATHERING_ROUND(HttpStatus.BAD_REQUEST, "SEARCH002", "유효하지 않은 회식 차수입니다."),
 
-    // 지도 관련
-    TMAP_API_CALL_FAILED(HttpStatus.BAD_REQUEST, "MAP001", "TMap API 호출에 실패했습니다."),
-    ADDRESS_CONVERSION_FAILED(HttpStatus.BAD_REQUEST, "MAP002", "주소로 변환할 수 없습니다."),
-    WALKING_DISTANCE_CALCULATION_FAILED(HttpStatus.BAD_REQUEST, "MAP003", "도보 거리를 계산할 수 없습니다."),
-    API_RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "MAP004", "TMap API 초당 호출 건수를 초과했습니다."),
-    API_QUOTA_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "MAP005", "TMap API 사용 할당량(SLA)을 초과했습니다."),
+    // KakaoMap 관련
+    ADDRESS_CONVERSION_FAILED(HttpStatus.BAD_REQUEST, "KAKAOMAP001", "주소로 변환할 수 없습니다."),
+
+    // TMap 관련
+    TMAP_API_CALL_FAILED(HttpStatus.BAD_REQUEST, "TMAP001", "TMap API 호출에 실패했습니다."),
+    API_RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "TMAP002", "TMap API 초당 호출 건수를 초과했습니다."),
+    API_QUOTA_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "TMAP003", "TMap API 사용 할당량(SLA)을 초과했습니다."),
+    WALKING_DISTANCE_CALCULATION_FAILED(HttpStatus.BAD_REQUEST, "TMAP004", "도보 거리를 계산할 수 없습니다."),
 
     // 유효성 검사 관련
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "VALIDATION001", "입력값이 유효하지 않습니다."),

--- a/src/main/java/wad/seoul_nolgoat/exception/GlobalExceptionHandler.java
+++ b/src/main/java/wad/seoul_nolgoat/exception/GlobalExceptionHandler.java
@@ -17,8 +17,8 @@ import static wad.seoul_nolgoat.exception.ErrorCode.*;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(ApiException.class)
-    public ResponseEntity<ErrorResponse> handleApiException(ApiException e) {
+    @ExceptionHandler(ApplicationException.class)
+    public ResponseEntity<ErrorResponse> handleApplicationException(ApplicationException e) {
         ErrorCode errorCode = e.getErrorCode();
 
         return ResponseEntity

--- a/src/main/java/wad/seoul_nolgoat/exception/GlobalExceptionHandler.java
+++ b/src/main/java/wad/seoul_nolgoat/exception/GlobalExceptionHandler.java
@@ -26,6 +26,15 @@ public class GlobalExceptionHandler {
                 .body(new ErrorResponse(errorCode));
     }
 
+    @ExceptionHandler(TMapException.class)
+    public ResponseEntity<ErrorResponse> handleTMapException(TMapException e) {
+        ErrorCode errorCode = e.getErrorCode();
+
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(new ErrorResponse(errorCode));
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException e) {
         Map<String, String> errors = new HashMap<>();

--- a/src/main/java/wad/seoul_nolgoat/exception/TMapException.java
+++ b/src/main/java/wad/seoul_nolgoat/exception/TMapException.java
@@ -3,12 +3,18 @@ package wad.seoul_nolgoat.exception;
 import lombok.Getter;
 
 @Getter
-public class TMapException extends ApiException {
+public class TMapException extends RuntimeException {
 
     private final ErrorCode errorCode;
 
     public TMapException(ErrorCode errorCode) {
-        super(errorCode);
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    // 기존 예외를 포함하기 위한 생성자
+    public TMapException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode.getMessage(), cause);
         this.errorCode = errorCode;
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/service/bookmark/BookmarkService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/bookmark/BookmarkService.java
@@ -11,7 +11,7 @@ import wad.seoul_nolgoat.domain.store.Store;
 import wad.seoul_nolgoat.domain.store.StoreRepository;
 import wad.seoul_nolgoat.domain.user.User;
 import wad.seoul_nolgoat.domain.user.UserRepository;
-import wad.seoul_nolgoat.exception.ApiException;
+import wad.seoul_nolgoat.exception.ApplicationException;
 import wad.seoul_nolgoat.web.bookmark.dto.response.StoreForBookmarkDto;
 
 import static wad.seoul_nolgoat.exception.ErrorCode.*;
@@ -28,9 +28,9 @@ public class BookmarkService {
     @Transactional
     public Long save(String loginId, Long storeId) {
         User user = userRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new ApiException(USER_NOT_FOUND));
+                .orElseThrow(() -> new ApplicationException(USER_NOT_FOUND));
         Store store = storeRepository.findById(storeId)
-                .orElseThrow(() -> new ApiException(STORE_NOT_FOUND));
+                .orElseThrow(() -> new ApplicationException(STORE_NOT_FOUND));
 
         return bookmarkRepository.save(
                 new Bookmark(
@@ -47,12 +47,12 @@ public class BookmarkService {
             Long storeId
     ) {
         Bookmark bookmark = bookmarkRepository.findByUserIdAndStoreId(userId, storeId)
-                .orElseThrow(() -> new ApiException(BOOKMARK_NOT_FOUND));
+                .orElseThrow(() -> new ApplicationException(BOOKMARK_NOT_FOUND));
 
         User user = userRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new ApiException(USER_NOT_FOUND));
+                .orElseThrow(() -> new ApplicationException(USER_NOT_FOUND));
         if (!user.getId().equals(userId)) {
-            throw new ApiException(BOOKMARK_REGISTRANT_MISMATCH);
+            throw new ApplicationException(BOOKMARK_REGISTRANT_MISMATCH);
         }
 
         bookmarkRepository.delete(bookmark);

--- a/src/main/java/wad/seoul_nolgoat/service/inquiry/InquiryService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/inquiry/InquiryService.java
@@ -9,7 +9,7 @@ import wad.seoul_nolgoat.domain.inquiry.Inquiry;
 import wad.seoul_nolgoat.domain.inquiry.InquiryRepository;
 import wad.seoul_nolgoat.domain.user.User;
 import wad.seoul_nolgoat.domain.user.UserRepository;
-import wad.seoul_nolgoat.exception.ApiException;
+import wad.seoul_nolgoat.exception.ApplicationException;
 import wad.seoul_nolgoat.util.mapper.InquiryMapper;
 import wad.seoul_nolgoat.web.inquiry.dto.request.InquirySaveDto;
 import wad.seoul_nolgoat.web.inquiry.dto.request.InquiryUpdateDto;
@@ -29,14 +29,14 @@ public class InquiryService {
     @Transactional
     public Long save(String loginId, InquirySaveDto inquirySaveDto) {
         User user = userRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new ApiException(USER_NOT_FOUND));
+                .orElseThrow(() -> new ApplicationException(USER_NOT_FOUND));
 
         return inquiryRepository.save(InquiryMapper.toEntity(user, inquirySaveDto)).getId();
     }
 
     public InquiryDetailsDto findByInquiryId(Long inquiryId) {
         Inquiry inquiry = inquiryRepository.findById(inquiryId)
-                .orElseThrow(() -> new ApiException(INQUIRY_NOT_FOUND));
+                .orElseThrow(() -> new ApplicationException(INQUIRY_NOT_FOUND));
 
         return InquiryMapper.toInquiryDetailsDto(inquiry);
     }
@@ -52,11 +52,11 @@ public class InquiryService {
             InquiryUpdateDto inquiryUpdateDto
     ) {
         Inquiry inquiry = inquiryRepository.findById(inquiryId)
-                .orElseThrow(() -> new ApiException(INQUIRY_NOT_FOUND));
+                .orElseThrow(() -> new ApplicationException(INQUIRY_NOT_FOUND));
 
         // 건의 작성자가 맞는지 검증
         if (!loginId.equals(inquiry.getUser().getLoginId())) {
-            throw new ApiException(INQUIRY_WRITER_MISMATCH);
+            throw new ApplicationException(INQUIRY_WRITER_MISMATCH);
         }
 
         inquiry.update(
@@ -69,11 +69,11 @@ public class InquiryService {
     @Transactional
     public void delete(String loginId, Long inquiryId) {
         Inquiry inquiry = inquiryRepository.findById(inquiryId)
-                .orElseThrow(() -> new ApiException(INQUIRY_NOT_FOUND));
+                .orElseThrow(() -> new ApplicationException(INQUIRY_NOT_FOUND));
 
         // 건의 작성자가 맞는지 검증
         if (!loginId.equals(inquiry.getUser().getLoginId())) {
-            throw new ApiException(INQUIRY_WRITER_MISMATCH);
+            throw new ApplicationException(INQUIRY_WRITER_MISMATCH);
         }
 
         inquiryRepository.delete(inquiry);

--- a/src/main/java/wad/seoul_nolgoat/service/kakaoMap/KakaoMapService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/kakaoMap/KakaoMapService.java
@@ -11,7 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
-import wad.seoul_nolgoat.exception.ApiException;
+import wad.seoul_nolgoat.exception.ApplicationException;
 import wad.seoul_nolgoat.service.kakaoMap.dto.StoreAdditionalInfoDto;
 import wad.seoul_nolgoat.web.search.dto.CoordinateDto;
 
@@ -187,7 +187,7 @@ public class KakaoMapService {
 
             return Optional.empty();
         } catch (Exception e) {
-            throw new ApiException(ADDRESS_CONVERSION_FAILED, e);
+            throw new ApplicationException(ADDRESS_CONVERSION_FAILED, e);
         }
     }
 

--- a/src/main/java/wad/seoul_nolgoat/service/kakaoMap/KakaoMapService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/kakaoMap/KakaoMapService.java
@@ -187,7 +187,7 @@ public class KakaoMapService {
 
             return Optional.empty();
         } catch (Exception e) {
-            throw new ApiException(ADDRESS_CONVERSION_FAILED);
+            throw new ApiException(ADDRESS_CONVERSION_FAILED, e);
         }
     }
 

--- a/src/main/java/wad/seoul_nolgoat/service/mail/MailService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/mail/MailService.java
@@ -13,7 +13,7 @@ import org.thymeleaf.spring6.SpringTemplateEngine;
 import wad.seoul_nolgoat.auth.service.RedisWithdrawalCodeService;
 import wad.seoul_nolgoat.domain.user.User;
 import wad.seoul_nolgoat.domain.user.UserRepository;
-import wad.seoul_nolgoat.exception.ApiException;
+import wad.seoul_nolgoat.exception.ApplicationException;
 
 import java.io.UnsupportedEncodingException;
 import java.util.Random;
@@ -31,7 +31,7 @@ public class MailService {
 
     public void sendEmailWithdrawalCode(String loginId) {
         User user = userRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new ApiException(USER_NOT_FOUND));
+                .orElseThrow(() -> new ApplicationException(USER_NOT_FOUND));
 
         String email = user.getEmail();
         String nickname = user.getNickname();
@@ -55,9 +55,9 @@ public class MailService {
 
             mailSender.send(message);
         } catch (MessagingException e) {
-            throw new ApiException(MAIL_SEND_FAILED, e);
+            throw new ApplicationException(MAIL_SEND_FAILED, e);
         } catch (UnsupportedEncodingException e) {
-            throw new ApiException(MAIL_SENDER_ENCODING_FAILED, e);
+            throw new ApplicationException(MAIL_SENDER_ENCODING_FAILED, e);
         }
     }
 

--- a/src/main/java/wad/seoul_nolgoat/service/mail/MailService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/mail/MailService.java
@@ -55,9 +55,9 @@ public class MailService {
 
             mailSender.send(message);
         } catch (MessagingException e) {
-            throw new ApiException(MAIL_SEND_FAILED);
+            throw new ApiException(MAIL_SEND_FAILED, e);
         } catch (UnsupportedEncodingException e) {
-            throw new ApiException(MAIL_SENDER_ENCODING_FAILED);
+            throw new ApiException(MAIL_SENDER_ENCODING_FAILED, e);
         }
     }
 

--- a/src/main/java/wad/seoul_nolgoat/service/notice/NoticeService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/notice/NoticeService.java
@@ -9,7 +9,7 @@ import wad.seoul_nolgoat.domain.notice.Notice;
 import wad.seoul_nolgoat.domain.notice.NoticeRepository;
 import wad.seoul_nolgoat.domain.user.User;
 import wad.seoul_nolgoat.domain.user.UserRepository;
-import wad.seoul_nolgoat.exception.ApiException;
+import wad.seoul_nolgoat.exception.ApplicationException;
 import wad.seoul_nolgoat.util.mapper.NoticeMapper;
 import wad.seoul_nolgoat.web.notice.dto.request.NoticeSaveDto;
 import wad.seoul_nolgoat.web.notice.dto.request.NoticeUpdateDto;
@@ -29,14 +29,14 @@ public class NoticeService {
     @Transactional
     public Long save(String loginId, NoticeSaveDto noticeSaveDto) {
         User user = userRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new ApiException(USER_NOT_FOUND));
+                .orElseThrow(() -> new ApplicationException(USER_NOT_FOUND));
 
         return noticeRepository.save(NoticeMapper.toEntity(user, noticeSaveDto)).getId();
     }
 
     public NoticeDetailsDto findByNoticeId(Long noticeId) {
         Notice notice = noticeRepository.findById(noticeId)
-                .orElseThrow(() -> new ApiException(NOTICE_NOT_FOUND));
+                .orElseThrow(() -> new ApplicationException(NOTICE_NOT_FOUND));
 
         return NoticeMapper.toNoticeDetailsDto(notice);
     }
@@ -52,11 +52,11 @@ public class NoticeService {
             NoticeUpdateDto noticeUpdateDto
     ) {
         Notice notice = noticeRepository.findById(noticeId)
-                .orElseThrow(() -> new ApiException(NOTICE_NOT_FOUND));
+                .orElseThrow(() -> new ApplicationException(NOTICE_NOT_FOUND));
 
         // 공지 작성자가 맞는지 검증
         if (!loginId.equals(notice.getUser().getLoginId())) {
-            throw new ApiException(NOTICE_WRITER_MISMATCH);
+            throw new ApplicationException(NOTICE_WRITER_MISMATCH);
         }
 
         notice.update(
@@ -68,11 +68,11 @@ public class NoticeService {
     @Transactional
     public void delete(String loginId, Long noticeId) {
         Notice notice = noticeRepository.findById(noticeId)
-                .orElseThrow(() -> new ApiException(NOTICE_NOT_FOUND));
+                .orElseThrow(() -> new ApplicationException(NOTICE_NOT_FOUND));
 
         // 공지 작성자가 맞는지 검증
         if (!loginId.equals(notice.getUser().getLoginId())) {
-            throw new ApiException(NOTICE_WRITER_MISMATCH);
+            throw new ApplicationException(NOTICE_WRITER_MISMATCH);
         }
 
         noticeRepository.delete(notice);
@@ -81,7 +81,7 @@ public class NoticeService {
     @Transactional
     public void increaseViews(Long noticeId) {
         Notice notice = noticeRepository.findById(noticeId)
-                .orElseThrow(() -> new ApiException(NOTICE_NOT_FOUND));
+                .orElseThrow(() -> new ApplicationException(NOTICE_NOT_FOUND));
         notice.increaseViews();
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/service/party/PartyService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/party/PartyService.java
@@ -224,7 +224,7 @@ public class PartyService {
         try {
             AdministrativeDistrict.valueOf(administrativeDistrict);
         } catch (IllegalArgumentException e) {
-            throw new ApiException(INVALID_ADMINISTRATIVE_DISTRICT);
+            throw new ApiException(INVALID_ADMINISTRATIVE_DISTRICT, e);
         }
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/service/review/ReviewService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/review/ReviewService.java
@@ -12,7 +12,7 @@ import wad.seoul_nolgoat.domain.store.Store;
 import wad.seoul_nolgoat.domain.store.StoreRepository;
 import wad.seoul_nolgoat.domain.user.User;
 import wad.seoul_nolgoat.domain.user.UserRepository;
-import wad.seoul_nolgoat.exception.ApiException;
+import wad.seoul_nolgoat.exception.ApplicationException;
 import wad.seoul_nolgoat.service.s3.S3Service;
 import wad.seoul_nolgoat.util.mapper.ReviewMapper;
 import wad.seoul_nolgoat.web.review.dto.request.ReviewSaveDto;
@@ -41,13 +41,13 @@ public class ReviewService {
             ReviewSaveDto reviewSaveDto
     ) {
         User user = userRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new ApiException(USER_NOT_FOUND));
+                .orElseThrow(() -> new ApplicationException(USER_NOT_FOUND));
 
         Store store = storeRepository.findById(storeId)
-                .orElseThrow(() -> new ApiException(STORE_NOT_FOUND));
+                .orElseThrow(() -> new ApplicationException(STORE_NOT_FOUND));
 
         if (reviewRepository.existsByUserIdAndStoreId(user.getId(), storeId)) {
-            throw new ApiException(DUPLICATE_REVIEW);
+            throw new ApplicationException(DUPLICATE_REVIEW);
         }
 
         Optional<String> imageUrl = Optional.ofNullable(image)
@@ -73,7 +73,7 @@ public class ReviewService {
     @Transactional
     public void update(Long reviewId, ReviewUpdateDto reviewUpdateDto) {
         Review review = reviewRepository.findById(reviewId)
-                .orElseThrow(() -> new ApiException(REVIEW_NOT_FOUND));
+                .orElseThrow(() -> new ApplicationException(REVIEW_NOT_FOUND));
 
         int previousNolgoatGrade = review.getGrade();
         int currentNolgoatGrade = reviewUpdateDto.getGrade();
@@ -91,10 +91,10 @@ public class ReviewService {
     @Transactional
     public void delete(String loginId, Long reviewId) {
         Review review = reviewRepository.findById(reviewId)
-                .orElseThrow(() -> new ApiException(REVIEW_NOT_FOUND));
+                .orElseThrow(() -> new ApplicationException(REVIEW_NOT_FOUND));
 
         if (!loginId.equals(review.getUser().getLoginId())) {
-            throw new ApiException(REVIEW_WRITER_MISMATCH);
+            throw new ApplicationException(REVIEW_WRITER_MISMATCH);
         }
 
         Store store = review.getStore();

--- a/src/main/java/wad/seoul_nolgoat/service/s3/S3Service.java
+++ b/src/main/java/wad/seoul_nolgoat/service/s3/S3Service.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-import wad.seoul_nolgoat.exception.ApiException;
+import wad.seoul_nolgoat.exception.ApplicationException;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -45,7 +45,7 @@ public class S3Service {
             );
             imageUrl = s3Resource.getURL().toString();
         } catch (IOException e) {
-            throw new ApiException(FILE_READ_FAILED, e);
+            throw new ApplicationException(FILE_READ_FAILED, e);
         }
 
         return imageUrl;
@@ -60,7 +60,7 @@ public class S3Service {
 
             s3Template.deleteObject(bucket, decodedKey);
         } catch (MalformedURLException e) {
-            throw new ApiException(INVALID_FILE_URL_FORMAT, e);
+            throw new ApplicationException(INVALID_FILE_URL_FORMAT, e);
         }
     }
 

--- a/src/main/java/wad/seoul_nolgoat/service/s3/S3Service.java
+++ b/src/main/java/wad/seoul_nolgoat/service/s3/S3Service.java
@@ -45,7 +45,7 @@ public class S3Service {
             );
             imageUrl = s3Resource.getURL().toString();
         } catch (IOException e) {
-            throw new ApiException(FILE_READ_FAILED);
+            throw new ApiException(FILE_READ_FAILED, e);
         }
 
         return imageUrl;
@@ -60,7 +60,7 @@ public class S3Service {
 
             s3Template.deleteObject(bucket, decodedKey);
         } catch (MalformedURLException e) {
-            throw new ApiException(INVALID_FILE_URL_FORMAT);
+            throw new ApiException(INVALID_FILE_URL_FORMAT, e);
         }
     }
 

--- a/src/main/java/wad/seoul_nolgoat/service/search/SearchService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/search/SearchService.java
@@ -5,7 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import wad.seoul_nolgoat.domain.store.StoreCategory;
 import wad.seoul_nolgoat.domain.store.StoreType;
-import wad.seoul_nolgoat.exception.ApiException;
+import wad.seoul_nolgoat.exception.ApplicationException;
 import wad.seoul_nolgoat.exception.TMapException;
 import wad.seoul_nolgoat.service.search.dto.SortConditionDto;
 import wad.seoul_nolgoat.service.search.dto.StoreForPossibleCategoriesDto;
@@ -65,7 +65,7 @@ public class SearchService {
         if (criteria.equals(NOLGOAT_GRADE_CRITERIA)) {
             return getCombinationsByNolgoatGrade(searchConditionDto);
         }
-        throw new ApiException(INVALID_SEARCH_CRITERIA);
+        throw new ApplicationException(INVALID_SEARCH_CRITERIA);
     }
 
     public List<String> searchPossibleCategories(PossibleCategoriesConditionDto possibleCategoriesConditionDto) {
@@ -168,7 +168,7 @@ public class SearchService {
                     Math.min(STORE_COMBINATION_SEARCH_LIMIT, combinationDtos.size())
             );
         }
-        throw new ApiException(INVALID_GATHERING_ROUND);
+        throw new ApplicationException(INVALID_GATHERING_ROUND);
     }
 
     private List<CombinationDto> getCombinationsByKakaoGrade(SearchConditionDto searchConditionDto) {
@@ -261,7 +261,7 @@ public class SearchService {
                     startCoordinate
             );
         }
-        throw new ApiException(INVALID_GATHERING_ROUND);
+        throw new ApplicationException(INVALID_GATHERING_ROUND);
     }
 
     private List<CombinationDto> getCombinationsByNolgoatGrade(SearchConditionDto searchConditionDto) {
@@ -354,7 +354,7 @@ public class SearchService {
                     startCoordinate
             );
         }
-        throw new ApiException(INVALID_GATHERING_ROUND);
+        throw new ApplicationException(INVALID_GATHERING_ROUND);
     }
 
     private List<CombinationDto> fetchWalkRouteInfoForCombinationDto(
@@ -398,7 +398,7 @@ public class SearchService {
 
                             return combination;
                         }
-                        throw new ApiException(INVALID_GATHERING_ROUND);
+                        throw new ApplicationException(INVALID_GATHERING_ROUND);
                     } catch (TMapException e) {
                         log.error("TMap Error : {}", e.getMessage());
                         int totalDistance = DistanceCalculator.calculateTotalDistanceForGradeWithFallback(

--- a/src/main/java/wad/seoul_nolgoat/service/store/StoreService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/store/StoreService.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import wad.seoul_nolgoat.domain.store.Store;
 import wad.seoul_nolgoat.domain.store.StoreRepository;
-import wad.seoul_nolgoat.exception.ApiException;
+import wad.seoul_nolgoat.exception.ApplicationException;
 import wad.seoul_nolgoat.service.store.dto.StoreUpdateDto;
 import wad.seoul_nolgoat.util.mapper.StoreMapper;
 import wad.seoul_nolgoat.web.store.dto.response.StoreDetailsDto;
@@ -25,13 +25,13 @@ public class StoreService {
 
     public StoreDetailsDto findStoreWithReviewsByStoreId(Long storeId) {
         return storeRepository.findStoreWithReviewsByStoreId(storeId)
-                .orElseThrow(() -> new ApiException(STORE_NOT_FOUND));
+                .orElseThrow(() -> new ApplicationException(STORE_NOT_FOUND));
     }
 
     @Transactional
     public void update(StoreUpdateDto storeUpdateDto) {
         Store store = storeRepository.findById(storeUpdateDto.getId())
-                .orElseThrow(() -> new ApiException(STORE_NOT_FOUND));
+                .orElseThrow(() -> new ApplicationException(STORE_NOT_FOUND));
         store.update(
                 storeUpdateDto.getName(),
                 storeUpdateDto.getCategory(),

--- a/src/main/java/wad/seoul_nolgoat/service/tMap/TMapService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/tMap/TMapService.java
@@ -136,11 +136,11 @@ public class TMapService {
         } catch (HttpClientErrorException.TooManyRequests e) {
             String body = e.getResponseBodyAsString();
             if (body.contains("QUOTA_EXCEEDED")) {
-                throw new TMapException(API_QUOTA_EXCEEDED);
+                throw new TMapException(API_QUOTA_EXCEEDED, e);
             }
-            throw new TMapException(API_RATE_LIMIT_EXCEEDED);
+            throw new TMapException(API_RATE_LIMIT_EXCEEDED, e);
         } catch (Exception e) {
-            throw new TMapException(TMAP_API_CALL_FAILED);
+            throw new TMapException(TMAP_API_CALL_FAILED, e);
         }
     }
 

--- a/src/main/java/wad/seoul_nolgoat/service/user/UserService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/user/UserService.java
@@ -9,7 +9,7 @@ import wad.seoul_nolgoat.auth.oauth2.dto.OAuth2UserDto;
 import wad.seoul_nolgoat.auth.oauth2.dto.OAuth2UserImpl;
 import wad.seoul_nolgoat.domain.user.User;
 import wad.seoul_nolgoat.domain.user.UserRepository;
-import wad.seoul_nolgoat.exception.ApiException;
+import wad.seoul_nolgoat.exception.ApplicationException;
 import wad.seoul_nolgoat.util.mapper.UserMapper;
 import wad.seoul_nolgoat.web.user.dto.response.UserProfileDto;
 
@@ -24,7 +24,7 @@ public class UserService {
 
     public UserProfileDto getLoginUserDetails(String loginId) {
         User user = userRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new ApiException(USER_NOT_FOUND));
+                .orElseThrow(() -> new ApplicationException(USER_NOT_FOUND));
 
         return UserMapper.toUserProfileDto(user);
     }
@@ -32,7 +32,7 @@ public class UserService {
     @Transactional
     public void deleteUserByLoginId(String loginId) {
         User user = userRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new ApiException(USER_NOT_FOUND));
+                .orElseThrow(() -> new ApplicationException(USER_NOT_FOUND));
         user.delete();
     }
 

--- a/src/test/java/wad/seoul_nolgoat/service/InquiryServiceTest.java
+++ b/src/test/java/wad/seoul_nolgoat/service/InquiryServiceTest.java
@@ -9,7 +9,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.test.context.ActiveProfiles;
-import wad.seoul_nolgoat.exception.ApiException;
+import wad.seoul_nolgoat.exception.ApplicationException;
 import wad.seoul_nolgoat.service.inquiry.InquiryService;
 import wad.seoul_nolgoat.web.inquiry.dto.request.InquiryUpdateDto;
 import wad.seoul_nolgoat.web.inquiry.dto.response.InquiryListDto;
@@ -62,7 +62,7 @@ public class InquiryServiceTest {
 
         // when // then
         assertThatThrownBy(() -> inquiryService.update(loginId, inquiryId, updateDto))
-                .isInstanceOf(ApiException.class)
+                .isInstanceOf(ApplicationException.class)
                 .hasMessage(INQUIRY_WRITER_MISMATCH.getMessage());
     }
 
@@ -75,7 +75,7 @@ public class InquiryServiceTest {
 
         // when // then
         assertThatThrownBy(() -> inquiryService.delete(loginId, inquiryId))
-                .isInstanceOf(ApiException.class)
+                .isInstanceOf(ApplicationException.class)
                 .hasMessage(INQUIRY_WRITER_MISMATCH.getMessage());
     }
 }

--- a/src/test/java/wad/seoul_nolgoat/service/NoticeServiceTest.java
+++ b/src/test/java/wad/seoul_nolgoat/service/NoticeServiceTest.java
@@ -9,7 +9,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.test.context.ActiveProfiles;
-import wad.seoul_nolgoat.exception.ApiException;
+import wad.seoul_nolgoat.exception.ApplicationException;
 import wad.seoul_nolgoat.service.notice.NoticeService;
 import wad.seoul_nolgoat.web.notice.dto.request.NoticeUpdateDto;
 import wad.seoul_nolgoat.web.notice.dto.response.NoticeListDto;
@@ -62,7 +62,7 @@ public class NoticeServiceTest {
 
         // when // then
         assertThatThrownBy(() -> noticeService.update(loginId, noticeId, updateDto))
-                .isInstanceOf(ApiException.class)
+                .isInstanceOf(ApplicationException.class)
                 .hasMessage(NOTICE_WRITER_MISMATCH.getMessage());
     }
 
@@ -75,7 +75,7 @@ public class NoticeServiceTest {
 
         // when // then
         assertThatThrownBy(() -> noticeService.delete(loginId, noticeId))
-                .isInstanceOf(ApiException.class)
+                .isInstanceOf(ApplicationException.class)
                 .hasMessage(NOTICE_WRITER_MISMATCH.getMessage());
     }
 }

--- a/src/test/java/wad/seoul_nolgoat/service/PartyServiceTest.java
+++ b/src/test/java/wad/seoul_nolgoat/service/PartyServiceTest.java
@@ -11,7 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import wad.seoul_nolgoat.domain.party.AdministrativeDistrict;
 import wad.seoul_nolgoat.domain.party.PartyRepository;
 import wad.seoul_nolgoat.domain.party.PartyUserRepository;
-import wad.seoul_nolgoat.exception.ApiException;
+import wad.seoul_nolgoat.exception.ApplicationException;
 import wad.seoul_nolgoat.service.party.PartyService;
 import wad.seoul_nolgoat.web.party.request.PartySaveDto;
 import wad.seoul_nolgoat.web.party.response.PartyDetailsDto;
@@ -79,7 +79,7 @@ public class PartyServiceTest {
 
         // when // then
         assertThatThrownBy(() -> partyService.createParty(loginId, partySaveDto, null))
-                .isInstanceOf(ApiException.class)
+                .isInstanceOf(ApplicationException.class)
                 .hasMessage(INVALID_ADMINISTRATIVE_DISTRICT.getMessage());
     }
 
@@ -100,7 +100,7 @@ public class PartyServiceTest {
             executorService.submit(() -> {
                 try {
                     partyService.joinParty(loginId, partyId, currentTime);
-                } catch (ApiException e) {
+                } catch (ApplicationException e) {
                     System.out.println(e.getErrorCode().getMessage());
                 } finally {
                     latch.countDown();
@@ -123,7 +123,7 @@ public class PartyServiceTest {
 
         // when // then
         assertThatThrownBy(() -> partyService.joinParty(loginId, partyId, currentTime))
-                .isInstanceOf(ApiException.class)
+                .isInstanceOf(ApplicationException.class)
                 .hasMessage(PARTY_ALREADY_CLOSED.getMessage());
     }
 
@@ -137,7 +137,7 @@ public class PartyServiceTest {
 
         // when // then
         assertThatThrownBy(() -> partyService.joinParty(loginId, partyId, currentTime))
-                .isInstanceOf(ApiException.class)
+                .isInstanceOf(ApplicationException.class)
                 .hasMessage(PARTY_ALREADY_DELETED.getMessage());
     }
 
@@ -151,7 +151,7 @@ public class PartyServiceTest {
 
         // when // then
         assertThatThrownBy(() -> partyService.joinParty(loginId, partyId, currentTime))
-                .isInstanceOf(ApiException.class)
+                .isInstanceOf(ApplicationException.class)
                 .hasMessage(PARTY_ALREADY_CLOSED.getMessage());
     }
 
@@ -165,7 +165,7 @@ public class PartyServiceTest {
 
         // when // then
         assertThatThrownBy(() -> partyService.joinParty(loginId, partyId, currentTime))
-                .isInstanceOf(ApiException.class)
+                .isInstanceOf(ApplicationException.class)
                 .hasMessage(PARTY_CREATOR_CANNOT_JOIN.getMessage());
     }
 
@@ -181,7 +181,7 @@ public class PartyServiceTest {
 
         // when // then
         assertThatThrownBy(() -> partyService.joinParty(loginIdB, partyId, currentTime))
-                .isInstanceOf(ApiException.class)
+                .isInstanceOf(ApplicationException.class)
                 .hasMessage(PARTY_ALREADY_JOINED.getMessage());
     }
 
@@ -202,7 +202,7 @@ public class PartyServiceTest {
 
         // when // then
         assertThatThrownBy(() -> partyService.joinParty(loginIdE, partyId, currentTime))
-                .isInstanceOf(ApiException.class)
+                .isInstanceOf(ApplicationException.class)
                 .hasMessage(PARTY_CAPACITY_EXCEEDED.getMessage());
     }
 
@@ -232,7 +232,7 @@ public class PartyServiceTest {
 
         // when // then
         assertThatThrownBy(() -> partyService.closeById(loginId, partyId))
-                .isInstanceOf(ApiException.class)
+                .isInstanceOf(ApplicationException.class)
                 .hasMessage(PARTY_CLOSE_NOT_AUTHORIZED.getMessage());
     }
 
@@ -245,7 +245,7 @@ public class PartyServiceTest {
 
         // when // then
         assertThatThrownBy(() -> partyService.closeById(loginId, partyId))
-                .isInstanceOf(ApiException.class)
+                .isInstanceOf(ApplicationException.class)
                 .hasMessage(PARTY_ALREADY_CLOSED.getMessage());
     }
 
@@ -273,7 +273,7 @@ public class PartyServiceTest {
 
         // when // then
         assertThatThrownBy(() -> partyService.deleteById(loginId, partyId))
-                .isInstanceOf(ApiException.class)
+                .isInstanceOf(ApplicationException.class)
                 .hasMessage(PARTY_DELETE_NOT_AUTHORIZED.getMessage());
     }
 
@@ -286,7 +286,7 @@ public class PartyServiceTest {
 
         // when // then
         assertThatThrownBy(() -> partyService.deleteById(loginId, partyId))
-                .isInstanceOf(ApiException.class)
+                .isInstanceOf(ApplicationException.class)
                 .hasMessage(PARTY_ALREADY_DELETED.getMessage());
     }
 
@@ -321,7 +321,7 @@ public class PartyServiceTest {
 
         // when // then
         assertThatThrownBy(() -> partyService.banParticipantFromParty(loginId, partyId, 2L))
-                .isInstanceOf(ApiException.class)
+                .isInstanceOf(ApplicationException.class)
                 .hasMessage(PARTY_KICK_NOT_AUTHORIZED.getMessage());
     }
 
@@ -334,7 +334,7 @@ public class PartyServiceTest {
 
         // when // then
         assertThatThrownBy(() -> partyService.banParticipantFromParty(hostLoginId, partyId, 2L))
-                .isInstanceOf(ApiException.class)
+                .isInstanceOf(ApplicationException.class)
                 .hasMessage(PARTY_USER_NOT_FOUND.getMessage());
     }
 


### PR DESCRIPTION
## ✔️ 작업 내용

- 예외 변환 시, 기존 예외를 포함하도록 수정했습니다.

## 📋 요약

- 예외 변환 시, 기존 예외를 포함하도록 수정
- 커스텀 예외명 `ApiException`을 `ApplicationException`으로 수정
- `TMapException`을 `ApplicationException`과 상속 관계가 아닌 별도의 커스텀 예외로 분리

## 🔒 관련 이슈

close #95

## ➕ 기타 사항