### PR TITLE
상점의 리뷰가 하나 있을 때 삭제되지 않는 오류 해결 

### DIFF
--- a/src/main/java/wad/seoul_nolgoat/domain/store/Store.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/store/Store.java
@@ -115,6 +115,10 @@ public class Store extends BaseTimeEntity {
         double previousNolgoatAverageGrade = this.nolgoatAverageGrade;
         int reviewCount = reviews.size();
 
+        if (reviewCount <= 1) {
+            this.nolgoatAverageGrade = 0;
+            return;
+        }
         this.nolgoatAverageGrade = ((previousNolgoatAverageGrade * reviewCount) - nolgoatGrade) / (reviewCount - 1);
     }
 


### PR DESCRIPTION
## ✔️ 작업 내용
상점의 리뷰가 하나 있을 때 삭제되지 않는 오류를 해결하려고 합니다.

## 📋 요약
`this.nolgoatAverageGrade = ((previousNolgoatAverageGrade * reviewCount) - nolgoatGrade) / (reviewCount - 1);`
reviewCount가 1일 때 분모가 0이 되어 오류 발생

## 🔒 관련 이슈

close #100

## ➕ 기타 사항