### PR TITLE
배포 스크립트에 파일 권한 설정 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,9 @@ jobs:
           echo "${{ secrets.APPLICATION_CONFIG_SEOUL }}" > ./src/main/resources/seoul-config.yml
           echo "${{ secrets.APPLICATION_CONFIG_TMAP }}" > ./src/main/resources/t-config.yml
 
+      - name: gradlew 실행 권한 부여
+        run: chmod +x gradlew
+
       - name: 테스트 및 빌드
         run: ./gradlew clean build
 


### PR DESCRIPTION
## ✔️ 작업 내용

- 스크립트에 gradlew 파일 실행 권한 설정 명령어를 추가합니다.

## 📋 요약

- 배포 스크립트에 파일 권한 설정 추가

## 🔒 관련 이슈

close #108

## ➕ 기타 사항