### PR TITLE
워크플로우 파일 분할

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,7 +1,7 @@
-name: deploy
+name: build-test
 
 on:
-  push:
+  pull_request:
     branches:
       - main
 
@@ -36,30 +36,3 @@ jobs:
 
       - name: 테스트 및 빌드
         run: ./gradlew clean build
-
-      - name: 빌드된 파일 이름 변경
-        run: mv ./build/libs/*SNAPSHOT.jar ./nolgoat.jar
-
-      - name: SCP를 사용해 EC2로 빌드 파일 전송
-        uses: appleboy/scp-action@v0.1.7
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USERNAME }}
-          key: ${{ secrets.EC2_PRIVATE_KEY }}
-          source: nolgoat.jar
-          target: /home/ubuntu/be-seoul-nolgoat/next
-
-      - name: SSH로 EC2 접속
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USERNAME }}
-          key: ${{ secrets.EC2_PRIVATE_KEY }}
-          script: |
-            rm -rf /home/ubuntu/be-seoul-nolgoat/current
-            mkdir /home/ubuntu/be-seoul-nolgoat/current
-            mv /home/ubuntu/be-seoul-nolgoat/next/nolgoat.jar /home/ubuntu/be-seoul-nolgoat/current/nolgoat.jar
-            cd /home/ubuntu/be-seoul-nolgoat/current
-            sudo fuser -k -n tcp 8080 || true
-            sudo nohup java -jar nolgoat.jar
-            rm -rf /home/ubuntu/be-seoul-nolgoat/next


### PR DESCRIPTION
## ✔️ 작업 내용

- 기존 워크플로우 파일을 분할하여 하나는 PR 작성 시 확인용으로, 다른 하나는 main 브랜치 배포용으로 분리했습니다.

## 📋 요약

- 워크플로우 파일 분할

## 🔒 관련 이슈

close #112

## ➕ 기타 사항