### PR TITLE
서버 공격 시도 URL 차단을 위한 Security 설정 변경

### DIFF
--- a/src/main/java/wad/seoul_nolgoat/auth/util/AuthUrlManager.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/util/AuthUrlManager.java
@@ -7,33 +7,60 @@ public class AuthUrlManager {
 
     public static RequestMatcher[] getUserRequestMatchers() {
         return new RequestMatcher[]{
-                new AntPathRequestMatcher("/api/auths/logout"),
-                new AntPathRequestMatcher("/api/auths/withdrawal/verification"),
-                new AntPathRequestMatcher("/api/auths/withdrawal"),
+                new AntPathRequestMatcher("/api/auths/token/reissue", "POST"),
+                new AntPathRequestMatcher("/api/auths/logout", "POST"),
+                new AntPathRequestMatcher("/api/auths/withdrawal/verification", "POST"),
+                new AntPathRequestMatcher("/api/auths/withdrawal", "DELETE"),
 
-                new AntPathRequestMatcher("/api/users/me"),
-                new AntPathRequestMatcher("/api/users/me/bookmarks"),
-                new AntPathRequestMatcher("/api/users/me/reviews"),
+                new AntPathRequestMatcher("/api/users/me", "GET"),
+                new AntPathRequestMatcher("/api/users/me/bookmarks", "GET"),
+                new AntPathRequestMatcher("/api/users/me/reviews", "GET"),
+                new AntPathRequestMatcher("/api/users/me/comments", "GET"),
 
-                new AntPathRequestMatcher("/api/stores/**"),
+                new AntPathRequestMatcher("/api/stores/{storeId}", "GET"),
+                new AntPathRequestMatcher("/api/stores/search", "GET"),
 
-                new AntPathRequestMatcher("/api/reviews/**"),
+                new AntPathRequestMatcher("/api/reviews/{storeId}", "POST"),
+                new AntPathRequestMatcher("/api/reviews/{reviewId}", "PUT"),
+                new AntPathRequestMatcher("/api/reviews/{reviewId}", "DELETE"),
 
-                new AntPathRequestMatcher("/api/bookmarks/**"),
+                new AntPathRequestMatcher("/api/bookmarks/{storeId}", "POST"),
+                new AntPathRequestMatcher("/api/bookmarks/{userId}/{storeId}", "DELETE"),
+                new AntPathRequestMatcher("/api/bookmarks/{userId}/{storeId}", "GET"),
 
-                new AntPathRequestMatcher("/api/search/**"),
+                new AntPathRequestMatcher("/api/comments/parties/{partyId}", "POST"),
+                new AntPathRequestMatcher("/api/comments/{commentId}", "PUT"),
+                new AntPathRequestMatcher("/api/comments/{commentId}", "DELETE"),
 
-                new AntPathRequestMatcher("/api/parties/**"),
+                new AntPathRequestMatcher("/api/search/all", "GET"),
+                new AntPathRequestMatcher("/api/search/possible/categories", "GET"),
+
+                new AntPathRequestMatcher("/api/parties", "POST"),
+                new AntPathRequestMatcher("/api/parties/{partyId}/join", "POST"),
+                new AntPathRequestMatcher("/api/parties/{partyId}/participants/me", "DELETE"),
+                new AntPathRequestMatcher("/api/parties/{partyId}", "POST"),
+                new AntPathRequestMatcher("/api/parties/{partyId}", "PUT"),
+                new AntPathRequestMatcher("/api/parties/{partyId}", "DELETE"),
+                new AntPathRequestMatcher("/api/parties/{partyId}/participants/{userId}", "DELETE"),
+                new AntPathRequestMatcher("/api/parties/{partyId}", "GET"),
+                new AntPathRequestMatcher("/api/parties", "GET"),
+                new AntPathRequestMatcher("/api/parties//me/created", "GET"),
+                new AntPathRequestMatcher("/api/parties/me/joined", "GET"),
 
                 new AntPathRequestMatcher("/api/inquiries", "POST"),
+                new AntPathRequestMatcher("/api/inquiries/{inquiryId}", "GET"),
+                new AntPathRequestMatcher("/api/inquiries", "GET"),
                 new AntPathRequestMatcher("/api/inquiries/{inquiryId}", "PUT"),
                 new AntPathRequestMatcher("/api/inquiries/{inquiryId}", "DELETE"),
 
                 new AntPathRequestMatcher("/api/notices", "POST"),
+                new AntPathRequestMatcher("/api/notices/{noticeId}", "GET"),
+                new AntPathRequestMatcher("/api/notices", "GET"),
                 new AntPathRequestMatcher("/api/notices/{noticeId}", "PUT"),
                 new AntPathRequestMatcher("/api/notices/{noticeId}", "DELETE"),
+                new AntPathRequestMatcher("/api/notices/{noticeId}/views", "PUT"),
 
-                new AntPathRequestMatcher("/api/mail/withdrawal/verification")
+                new AntPathRequestMatcher("/api/mail/withdrawal/verification", "POST")
         };
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/config/SecurityConfig.java
+++ b/src/main/java/wad/seoul_nolgoat/config/SecurityConfig.java
@@ -65,7 +65,7 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(AuthUrlManager.getUserRequestMatchers()).authenticated()
-                        .anyRequest().permitAll()
+                        .anyRequest().denyAll()
                 )
                 .addFilterBefore(authFilter, UsernamePasswordAuthenticationFilter.class)
                 .sessionManagement(s -> s

--- a/src/main/java/wad/seoul_nolgoat/web/comment/CommentController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/comment/CommentController.java
@@ -47,7 +47,7 @@ public class CommentController {
     }
 
     @Operation(summary = "댓글 수정")
-    @PatchMapping("/{commentId}")
+    @PutMapping("/{commentId}")
     public ResponseEntity<Void> update(
             @AuthenticationPrincipal OAuth2User loginUser,
             @Valid @RequestBody CommentUpdateDto commentUpdateDto,

--- a/src/main/java/wad/seoul_nolgoat/web/inquiry/InquiryController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/inquiry/InquiryController.java
@@ -59,7 +59,7 @@ public class InquiryController {
     }
 
     @Operation(summary = "건의 사항 수정")
-    @PatchMapping("/{inquiryId}")
+    @PutMapping("/{inquiryId}")
     public ResponseEntity<Void> update(
             @AuthenticationPrincipal OAuth2User loginUser,
             @PathVariable Long inquiryId,

--- a/src/main/java/wad/seoul_nolgoat/web/notice/NoticeController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/notice/NoticeController.java
@@ -1,6 +1,5 @@
 package wad.seoul_nolgoat.web.notice;
 
-import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -60,7 +59,7 @@ public class NoticeController {
     }
 
     @Operation(summary = "공지 사항 수정")
-    @PatchMapping("/{noticeId}")
+    @PutMapping("/{noticeId}")
     public ResponseEntity<Void> update(
             @AuthenticationPrincipal OAuth2User loginUser,
             @PathVariable Long noticeId,
@@ -90,8 +89,8 @@ public class NoticeController {
                 .build();
     }
 
-    @Hidden
-    @PatchMapping("/{noticeId}/views")
+    @Operation(summary = "공지 사항 조회수 증가")
+    @PutMapping("/{noticeId}/views")
     public ResponseEntity<Void> increaseViews(@PathVariable Long noticeId) {
         noticeService.increaseViews(noticeId);
         return ResponseEntity

--- a/src/main/java/wad/seoul_nolgoat/web/party/PartyController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/party/PartyController.java
@@ -78,7 +78,7 @@ public class PartyController {
     }
 
     @Operation(summary = "파티 수정")
-    @PatchMapping("/{partyId}")
+    @PutMapping("/{partyId}")
     public ResponseEntity<Void> update(
             @AuthenticationPrincipal OAuth2User loginUser,
             @Valid @RequestBody PartyUpdateDto partyUpdateDto,

--- a/src/main/java/wad/seoul_nolgoat/web/review/ReviewController.java
+++ b/src/main/java/wad/seoul_nolgoat/web/review/ReviewController.java
@@ -51,7 +51,7 @@ public class ReviewController {
 
     @Hidden
     // 현재 사용하지 않음
-    @PatchMapping("/{reviewId}")
+    @PutMapping("/{reviewId}")
     public ResponseEntity<Void> update(
             @PathVariable Long reviewId,
             @Valid @RequestBody ReviewUpdateDto reviewUpdateDto


### PR DESCRIPTION
## ✔️ 작업 내용

- 서버 공격 시도 URL 차단을 위해 애플리케이션 엔드포인트 이외의 모든 요청을 거부하도록 Security 설정을 변경했습니다.

## 📋 요약

- 서버 공격 시도 URL 차단을 위한 Security 설정 변경

## 🔒 관련 이슈

close #126

## ➕ 기타 사항