### PR TITLE
파티 응답 DTO 수정 및 어노테이션 오류 해결 

### DIFF
--- a/src/main/java/wad/seoul_nolgoat/domain/party/PartyRepositoryCustomImpl.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/party/PartyRepositoryCustomImpl.java
@@ -137,6 +137,9 @@ public class PartyRepositoryCustomImpl implements PartyRepositoryCustom {
     }
 
     private BooleanExpression createStatusCondition(PartyStatus status) {
+        if (status == null) {
+            return null;
+        }
         if (status.equals(PartyStatus.OPENED)) {
             return party.isClosed.isFalse();
         }

--- a/src/main/java/wad/seoul_nolgoat/domain/partyuser/PartyUserRepositoryCustomImpl.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/partyuser/PartyUserRepositoryCustomImpl.java
@@ -16,7 +16,7 @@ public class PartyUserRepositoryCustomImpl implements PartyUserRepositoryCustom 
 
     @Override
     public List<ParticipantDto> findParticipantsByPartyId(Long partyId) {
-        jpaQueryFactory
+        return jpaQueryFactory
                 .select(
                         Projections.constructor(
                                 ParticipantDto.class,
@@ -30,7 +30,5 @@ public class PartyUserRepositoryCustomImpl implements PartyUserRepositoryCustom 
                 .where(partyUser.party.id.eq(partyId))
                 .orderBy(partyUser.createdDate.asc())
                 .fetch();
-
-        return List.of();
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/util/DateTimeUtil.java
+++ b/src/main/java/wad/seoul_nolgoat/util/DateTimeUtil.java
@@ -2,12 +2,45 @@ package wad.seoul_nolgoat.util;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 
 public class DateTimeUtil {
 
     // LocalDateTime을 "yyyy-MM-dd" 형식의 문자열로 변환
     public static String formatDate(LocalDateTime dateTime) {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
         return dateTime.format(formatter);
+    }
+
+    // 현재 시간과의 차이를 반환
+    public static String timeAgo(LocalDateTime dateTime) {
+        LocalDateTime now = LocalDateTime.now();
+
+        long years = ChronoUnit.YEARS.between(dateTime, now);
+        if (years >= 1) {
+            return years + "년 전";
+        }
+
+        long months = ChronoUnit.MONTHS.between(dateTime, now);
+        if (months >= 1) {
+            return months + "달 전";
+        }
+
+        long days = ChronoUnit.DAYS.between(dateTime, now);
+        if (days >= 1) {
+            return days + "일 전";
+        }
+
+        long hours = ChronoUnit.HOURS.between(dateTime, now);
+        if (hours >= 1) {
+            return hours + "시간 전";
+        }
+
+        long minutes = ChronoUnit.MINUTES.between(dateTime, now);
+        if (minutes >= 1) {
+            return minutes + "분 전";
+        }
+
+        return "방금 전";
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/web/party/request/PartySaveDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/party/request/PartySaveDto.java
@@ -22,7 +22,7 @@ public class PartySaveDto {
     @Max(value = 30, message = "참여 가능 인원은 30명을 초과할 수 없습니다.")
     private final int maxCapacity;
 
-    @NotBlank
+    @NotNull
     @Future(message = "모임일은 현재 시간 이후여야 합니다.")
     private final LocalDateTime meetingDate;
 

--- a/src/main/java/wad/seoul_nolgoat/web/party/request/PartyUpdateDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/party/request/PartyUpdateDto.java
@@ -22,7 +22,7 @@ public class PartyUpdateDto {
     @Max(value = 30, message = "참여 가능 인원은 30명을 초과할 수 없습니다.")
     private final int maxCapacity;
 
-    @NotBlank
+    @NotNull
     @FutureOrPresent(message = "모임일은 현재 시간 이후여야 합니다.")
     private final LocalDateTime meetingDate;
 

--- a/src/main/java/wad/seoul_nolgoat/web/party/response/PartyDetailsDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/party/response/PartyDetailsDto.java
@@ -3,6 +3,7 @@ package wad.seoul_nolgoat.web.party.response;
 import lombok.Getter;
 import wad.seoul_nolgoat.domain.party.AdministrativeDistrict;
 import wad.seoul_nolgoat.domain.party.Party;
+import wad.seoul_nolgoat.util.DateTimeUtil;
 import wad.seoul_nolgoat.web.comment.dto.response.CommentDetailsForPartyDto;
 
 import java.time.LocalDateTime;
@@ -19,7 +20,7 @@ public class PartyDetailsDto {
     private final boolean isClosed;
     private final String district;
     private final int currentCount;
-    private final LocalDateTime createdDate;
+    private final String createdDateAgo;
     private final Long hostId;
     private final String hostNickname;
     private final String hostProfileImage;
@@ -55,7 +56,7 @@ public class PartyDetailsDto {
         this.isClosed = isClosed;
         this.district = district.getDisplayName();
         this.currentCount = currentCount;
-        this.createdDate = createdDate;
+        this.createdDateAgo = DateTimeUtil.timeAgo(createdDate);
         this.hostId = hostId;
         this.hostNickname = hostNickname;
         this.hostProfileImage = hostProfileImage;

--- a/src/main/java/wad/seoul_nolgoat/web/party/response/PartyDetailsForListDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/party/response/PartyDetailsForListDto.java
@@ -3,6 +3,7 @@ package wad.seoul_nolgoat.web.party.response;
 import lombok.Getter;
 import wad.seoul_nolgoat.domain.party.AdministrativeDistrict;
 import wad.seoul_nolgoat.domain.party.Party;
+import wad.seoul_nolgoat.util.DateTimeUtil;
 
 import java.time.LocalDateTime;
 
@@ -16,7 +17,7 @@ public class PartyDetailsForListDto {
     private final boolean isClosed;
     private final String district;
     private final int currentCount;
-    private final LocalDateTime createdDate;
+    private final String createdDateAgo;
     private final Long hostId;
     private final String hostNickname;
     private final String hostProfileImage;
@@ -41,7 +42,7 @@ public class PartyDetailsForListDto {
         this.isClosed = isClosed;
         this.district = district.getDisplayName();
         this.currentCount = currentCount;
-        this.createdDate = createdDate;
+        this.createdDateAgo = DateTimeUtil.timeAgo(createdDate);
         this.hostId = hostId;
         this.hostNickname = hostNickname;
         this.hostProfileImage = hostProfileImage;


### PR DESCRIPTION
## ✔️ 작업 내용
- 파티 응답 DTO를 수정했습니다.
- 올바른 유효성 검증 어노테이션을 적용했습니다.  

## 📋 요약
- 파티 조회 DTO의 createdDateAgo 필드를 문자열로 반환하도록 수정
- 문자열이 아닌 변수에는 @NotBlank 대신 @NotNull을 적용 

## 🔒 관련 이슈

close #136 

## ➕ 기타 사항