### PR TITLE
추가한 로직이 반영되지 않은 테스트 수정

### DIFF
--- a/src/test/java/wad/seoul_nolgoat/service/PartyServiceTest.java
+++ b/src/test/java/wad/seoul_nolgoat/service/PartyServiceTest.java
@@ -377,7 +377,7 @@ public class PartyServiceTest {
                 .hasMessage(PARTY_USER_NOT_FOUND.getMessage());
     }
 
-    @DisplayName("파티 단건 조회")
+    @DisplayName("파티 단건 조회 시, 모임 일이 지났다면 파티가 자동으로 마감됩니다.")
     @Test
     void update_party_to_closed_when_finding_party_after_meeting_date() {
         // given
@@ -405,7 +405,7 @@ public class PartyServiceTest {
                         "Party Content B",
                         6,
                         LocalDateTime.of(2024, 12, 31, 23, 59, 59),
-                        false,
+                        true,
                         1
                 );
     }


### PR DESCRIPTION
## ✔️ 작업 내용

- 모임 일이 지난 파티는 자동 마감되는 로직을 테스트에 반영

## 📋 요약

- 모임 일이 지난 파티는 자동 마감되는 로직을 테스트에 반영

## 🔒 관련 이슈

close #138

## ➕ 기타 사항