### PR TITLE
Access 토큰 재발급 요청 URL은 인증이 필요 없도록 설정 수정

### DIFF
--- a/src/main/java/wad/seoul_nolgoat/auth/security/AuthFilter.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/security/AuthFilter.java
@@ -13,7 +13,6 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import wad.seoul_nolgoat.auth.oauth2.dto.OAuth2UserDto;
 import wad.seoul_nolgoat.auth.oauth2.dto.OAuth2UserImpl;
 import wad.seoul_nolgoat.auth.service.AuthService;
-import wad.seoul_nolgoat.auth.util.AuthUrlManager;
 import wad.seoul_nolgoat.exception.ApplicationException;
 
 import java.io.IOException;
@@ -27,6 +26,7 @@ import static wad.seoul_nolgoat.auth.service.AuthService.AUTHORIZATION_HEADER;
 public class AuthFilter extends OncePerRequestFilter {
 
     private final AuthService authService;
+    private final AuthUrlManager authUrlManager;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -58,7 +58,7 @@ public class AuthFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
-        return Arrays.stream(AuthUrlManager.getUserRequestMatchers())
+        return Arrays.stream(authUrlManager.getUserRequestMatchers())
                 .noneMatch(matcher -> matcher.matches(request));
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/auth/security/AuthUrlManager.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/security/AuthUrlManager.java
@@ -1,11 +1,13 @@
-package wad.seoul_nolgoat.auth.util;
+package wad.seoul_nolgoat.auth.security;
 
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.stereotype.Component;
 
+@Component
 public class AuthUrlManager {
 
-    public static RequestMatcher[] getUserRequestMatchers() {
+    public RequestMatcher[] getUserRequestMatchers() {
         return new RequestMatcher[]{
                 new AntPathRequestMatcher("/api/auths/token/reissue", "POST"),
                 new AntPathRequestMatcher("/api/auths/logout", "POST"),

--- a/src/main/java/wad/seoul_nolgoat/auth/security/AuthUrlManager.java
+++ b/src/main/java/wad/seoul_nolgoat/auth/security/AuthUrlManager.java
@@ -9,7 +9,6 @@ public class AuthUrlManager {
 
     public RequestMatcher[] getUserRequestMatchers() {
         return new RequestMatcher[]{
-                new AntPathRequestMatcher("/api/auths/token/reissue", "POST"),
                 new AntPathRequestMatcher("/api/auths/logout", "POST"),
                 new AntPathRequestMatcher("/api/auths/withdrawal/verification", "POST"),
                 new AntPathRequestMatcher("/api/auths/withdrawal", "DELETE"),
@@ -64,5 +63,9 @@ public class AuthUrlManager {
 
                 new AntPathRequestMatcher("/api/mail/withdrawal/verification", "POST")
         };
+    }
+
+    public RequestMatcher getReissueTokenRequestMatcher() {
+        return new AntPathRequestMatcher("/api/auths/token/reissue", "POST");
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/config/SecurityConfig.java
+++ b/src/main/java/wad/seoul_nolgoat/config/SecurityConfig.java
@@ -19,8 +19,8 @@ import wad.seoul_nolgoat.auth.oauth2.security.CustomSuccessHandler;
 import wad.seoul_nolgoat.auth.oauth2.security.OAuth2AuthorizationRequestResolverImpl;
 import wad.seoul_nolgoat.auth.oauth2.security.RedisOAuth2AuthorizedClientService;
 import wad.seoul_nolgoat.auth.security.AuthFilter;
+import wad.seoul_nolgoat.auth.security.AuthUrlManager;
 import wad.seoul_nolgoat.auth.security.AuthenticationEntryPointImpl;
-import wad.seoul_nolgoat.auth.util.AuthUrlManager;
 
 import java.util.List;
 
@@ -34,6 +34,7 @@ public class SecurityConfig {
     private final RedisOAuth2AuthorizedClientService oAuth2AuthorizedClientService;
     private final CustomSuccessHandler successHandler;
     private final AuthenticationEntryPointImpl authenticationEntryPoint;
+    private final AuthUrlManager authUrlManager;
     private final AuthFilter authFilter;
 
     @Value("${app.urls.frontend-base-url}")
@@ -64,7 +65,8 @@ public class SecurityConfig {
                         .authenticationEntryPoint(authenticationEntryPoint)
                 )
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(AuthUrlManager.getUserRequestMatchers()).authenticated()
+                        .requestMatchers(authUrlManager.getUserRequestMatchers()).authenticated()
+                        .requestMatchers(authUrlManager.getReissueTokenRequestMatcher()).permitAll()
                         .anyRequest().denyAll()
                 )
                 .addFilterBefore(authFilter, UsernamePasswordAuthenticationFilter.class)


### PR DESCRIPTION
## ✔️ 작업 내용

- AuthUrlManager 수정
  - 빈으로 등록 및 의존성 주입
  - 폴더 구조 변경 (`/auth/util` -> `/auth/security`)
- SecurityConfig 수정
  - 토큰 재발급 요청은 `permitAll()` 처리

## 📋 요약

- Access 토큰 재발급 요청 URL은 인증이 필요 없도록 설정 수정

## 🔒 관련 이슈

close #143

## ➕ 기타 사항