### PR TITLE
파티 생성 유효성 검사 기준 및 파티 목록 조회 정렬 방식 수정

### DIFF
--- a/src/main/java/wad/seoul_nolgoat/domain/party/PartyRepositoryCustomImpl.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/party/PartyRepositoryCustomImpl.java
@@ -158,7 +158,7 @@ public class PartyRepositoryCustomImpl implements PartyRepositoryCustom {
 
     private OrderSpecifier<?> getOrderSpecifier(String sortField) {
         if (sortField.equals("meetingDate")) {
-            return party.meetingDate.desc();
+            return party.meetingDate.asc();
         }
         return party.createdDate.desc();
     }

--- a/src/main/java/wad/seoul_nolgoat/web/party/request/PartySaveDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/party/request/PartySaveDto.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 public class PartySaveDto {
 
     @NotBlank
-    @Size(max = 25, message = "제목은 25자 이내여야 합니다.")
+    @Size(max = 40, message = "제목은 40자 이내여야 합니다.")
     private final String title;
 
     @NotBlank
@@ -23,7 +23,7 @@ public class PartySaveDto {
     private final int maxCapacity;
 
     @NotNull
-    @Future(message = "모임일은 현재 시간 이후여야 합니다.")
+    @FutureOrPresent(message = "모임 일은 현재 시간 이후여야 합니다.")
     private final LocalDateTime meetingDate;
 
     @NotBlank

--- a/src/main/java/wad/seoul_nolgoat/web/party/request/PartyUpdateDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/party/request/PartyUpdateDto.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 public class PartyUpdateDto {
 
     @NotBlank
-    @Size(max = 25, message = "제목은 25자 이내여야 합니다.")
+    @Size(max = 40, message = "제목은 40자 이내여야 합니다.")
     private final String title;
 
     @NotBlank
@@ -23,7 +23,7 @@ public class PartyUpdateDto {
     private final int maxCapacity;
 
     @NotNull
-    @FutureOrPresent(message = "모임일은 현재 시간 이후여야 합니다.")
+    @FutureOrPresent(message = "모임 일은 현재 시간 이후여야 합니다.")
     private final LocalDateTime meetingDate;
 
     @NotBlank


### PR DESCRIPTION
## ✔️ 작업 내용

- 파티 요청 DTO 수정
  - 제목 글자 제한을 40자로 수정
  - 모임 일 유효성 검증 통일 (`@FutureOrPresent`)
- 파티 목록 조회 시, 모임 일 기준 정렬은 오름차순으로 수정

## 📋 요약

- 파티 생성 유효성 검사 기준 및 파티 목록 조회 정렬 방식 수정

## 🔒 관련 이슈

close #145

## ➕ 기타 사항