### PR TITLE
[Release] 2차 배포

### DIFF
--- a/src/main/java/wad/seoul_nolgoat/domain/comment/Comment.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/comment/Comment.java
@@ -24,14 +24,20 @@ public class Comment extends BaseTimeEntity {
     private Party party;
 
     private String content;
+    private boolean isDeleted;
 
     public Comment(User writer, Party party, String content) {
         this.writer = writer;
         this.party = party;
         this.content = content;
+        this.isDeleted = false;
     }
 
     public void update(String content) {
         this.content = content;
+    }
+
+    public void delete() {
+        this.isDeleted = true;
     }
 }

--- a/src/main/java/wad/seoul_nolgoat/domain/comment/CommentRepositoryCustomImpl.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/comment/CommentRepositoryCustomImpl.java
@@ -18,6 +18,8 @@ import static wad.seoul_nolgoat.domain.comment.QComment.comment;
 @RequiredArgsConstructor
 public class CommentRepositoryCustomImpl implements CommentRepositoryCustom {
 
+    private static final String DELETED_COMMENT_MESSAGE = "삭제된 댓글입니다";
+
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
@@ -27,7 +29,10 @@ public class CommentRepositoryCustomImpl implements CommentRepositoryCustom {
                         Projections.constructor(
                                 CommentDetailsForUserDto.class,
                                 comment.id,
-                                comment.content,
+                                Expressions.cases()
+                                        .when(comment.isDeleted.isTrue())
+                                        .then(DELETED_COMMENT_MESSAGE)
+                                        .otherwise(comment.content),
                                 comment.createdDate,
                                 comment.isDeleted,
                                 comment.party.id
@@ -61,7 +66,7 @@ public class CommentRepositoryCustomImpl implements CommentRepositoryCustom {
                                 comment.id,
                                 Expressions.cases()
                                         .when(comment.isDeleted.isTrue())
-                                        .then("")
+                                        .then(DELETED_COMMENT_MESSAGE)
                                         .otherwise(comment.content),
                                 comment.createdDate,
                                 comment.isDeleted,

--- a/src/main/java/wad/seoul_nolgoat/domain/comment/CommentRepositoryCustomImpl.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/comment/CommentRepositoryCustomImpl.java
@@ -1,6 +1,7 @@
 package wad.seoul_nolgoat.domain.comment;
 
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -58,7 +59,10 @@ public class CommentRepositoryCustomImpl implements CommentRepositoryCustom {
                         Projections.constructor(
                                 CommentDetailsForPartyDto.class,
                                 comment.id,
-                                comment.content,
+                                Expressions.cases()
+                                        .when(comment.isDeleted.isTrue())
+                                        .then("")
+                                        .otherwise(comment.content),
                                 comment.createdDate,
                                 comment.isDeleted,
                                 comment.writer.id,

--- a/src/main/java/wad/seoul_nolgoat/domain/comment/CommentRepositoryCustomImpl.java
+++ b/src/main/java/wad/seoul_nolgoat/domain/comment/CommentRepositoryCustomImpl.java
@@ -28,6 +28,7 @@ public class CommentRepositoryCustomImpl implements CommentRepositoryCustom {
                                 comment.id,
                                 comment.content,
                                 comment.createdDate,
+                                comment.isDeleted,
                                 comment.party.id
                         )
                 )
@@ -59,6 +60,7 @@ public class CommentRepositoryCustomImpl implements CommentRepositoryCustom {
                                 comment.id,
                                 comment.content,
                                 comment.createdDate,
+                                comment.isDeleted,
                                 comment.writer.id,
                                 comment.writer.nickname,
                                 comment.writer.profileImage

--- a/src/main/java/wad/seoul_nolgoat/service/comment/CommentService.java
+++ b/src/main/java/wad/seoul_nolgoat/service/comment/CommentService.java
@@ -69,7 +69,7 @@ public class CommentService {
             throw new ApplicationException(COMMENT_DELETE_NOT_AUTHORIZED);
         }
 
-        commentRepository.delete(comment);
+        comment.delete();
     }
 
     public Page<CommentDetailsForUserDto> findCommentsByLoginId(String loginId, Pageable pageable) {

--- a/src/main/java/wad/seoul_nolgoat/web/comment/dto/response/CommentDetailsForPartyDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/comment/dto/response/CommentDetailsForPartyDto.java
@@ -12,6 +12,7 @@ public class CommentDetailsForPartyDto {
     private final Long commentId;
     private final String content;
     private final LocalDateTime createdDate;
+    private final Boolean isDeleted;
     private final Long writerId;
     private final String writerNickname;
     private final String writerProfileImage;

--- a/src/main/java/wad/seoul_nolgoat/web/comment/dto/response/CommentDetailsForUserDto.java
+++ b/src/main/java/wad/seoul_nolgoat/web/comment/dto/response/CommentDetailsForUserDto.java
@@ -12,5 +12,6 @@ public class CommentDetailsForUserDto {
     private final Long commentId;
     private final String content;
     private final LocalDateTime createdDate;
+    private final Boolean isDeleted;
     private final Long partyId;
 }


### PR DESCRIPTION
## ✔️ 작업 내용

- Comment 엔티티 클래스 스펙 수정
  - Soft Delete 적용을 위해 `isDeleted` 필드 추가 (응답 DTO에도 반영)
  - 조회 시, 삭제 여부를 판단하여 `isDeleted`가 true면 내용을 '삭제된 댓글입니다'로 변환

## 📋 요약

- 2차 배포

## 🔒 관련 이슈

close #

## ➕ 기타 사항